### PR TITLE
Refactor/split api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ tasks.named('test') {
     filter {
         includeTestsMatching "toy.yogiyo.api.*"
         includeTestsMatching "toy.yogiyo.document.*"
+        includeTestsMatching "toy.yogiyo.common.login.LoginControllerTest"
     }
 }
 

--- a/src/docs/asciidoc/DeliveryPlace-API.adoc
+++ b/src/docs/asciidoc/DeliveryPlace-API.adoc
@@ -2,26 +2,26 @@
 == Delivery Place API
 
 === 배달 가능 지역 추가
-`POST /delivery-place/shop/{shopId}/add`
+`POST /owner/delivery-place/shop/{shopId}/add`
 
 operation::delivery-place/add[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 배달 가능 지역 삭제
-`DELETE /delivery-place/{deliveryPlaceId}/delete`
+`DELETE /owner/delivery-place/{deliveryPlaceId}/delete`
 
 operation::delivery-place/delete[snippets='http-request,http-response,request-headers,path-parameters']
 
 === 배달 요금 수정
-`PATCH /delivery-place/{deliveryPlaceId}/delivery-price/update`
+`PATCH /owner/delivery-place/{deliveryPlaceId}/delivery-price/update`
 
 operation::delivery-place/update-delivery-price[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 배달 요금 일괄 수정
-`PATCH /delivery-place/shop/{shopId}/delivery-price/update`
+`PATCH /owner/delivery-place/shop/{shopId}/delivery-price/update`
 
 operation::delivery-place/update-all-delivery-price[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 배달 요금 조회
-`GET /delivery-place/{deliveryPlaceId}/delivery-price`
+`GET /owner/delivery-place/{deliveryPlaceId}/delivery-price`
 
 operation::delivery-place/get-delivery-price[snippets='http-request,http-response,path-parameters,response-fields']

--- a/src/docs/asciidoc/Like-API.adoc
+++ b/src/docs/asciidoc/Like-API.adoc
@@ -3,12 +3,12 @@
 
 [[Like-toggle]]
 === 찜하기(toggle)
-`POST /like/{shopid}`
+`POST /member/like/{shopid}`
 
 operation::like[snippets='http-request,http-response,request-headers,path-parameters']
 
 [[Like-scroll]]
 === 찜 목록 조회
-`GET /like/list`
+`GET /member/like/list`
 
 operation::like/list[snippets='http-request,http-response,request-headers,response-fields']

--- a/src/docs/asciidoc/Management-Review-API.adoc
+++ b/src/docs/asciidoc/Management-Review-API.adoc
@@ -3,19 +3,19 @@
 
 [[Review-Shop]]
 === 리뷰 확인
-`GET /management/review/shop/{shopId}`
+`GET /owner/review/shop/{shopId}`
 
 operation::management/review/shop[snippets='http-request,http-response,path-parameters,request-parameters,response-fields']
 
 [[Review-Reply]]
 === 답변 작성/수정
-`PATCH /management/review/{reviewId}/reply`
+`PATCH /owner/review/{reviewId}/reply`
 
 operation::management/review/reply[snippets='http-request,http-response,path-parameters,request-headers,request-fields']
 
 [[Review-Reply-Delete]]
 === 답변 삭제
-`DELETE /management/review/{reviewId}`
+`DELETE /owner/review/{reviewId}`
 
 operation::management/review/reply-delete[snippets='http-request,http-response,path-parameters,request-headers']
 

--- a/src/docs/asciidoc/Member-API.adoc
+++ b/src/docs/asciidoc/Member-API.adoc
@@ -9,19 +9,19 @@ operation::member/join[snippets='http-request,http-response,request-fields,respo
 
 [[Member-default-login]]
 === 멤버 기본 로그인
-`POST /memberLogin`
+`POST /member/login`
 
 operation::default/login[snippets='http-request,http-response,request-fields,response-fields,response-headers']
 
 [[Member-social-login]]
 === 멤버 소셜 로그인
-`POST /memberLogin`
+`POST /member/login`
 
 operation::social/login[snippets='http-request,http-response,request-fields,response-fields,response-headers']
 
 [[Member-logout]]
 === 멤버 로그아웃
-`POST /memberLogout/{memberId}`
+`POST /member/logout/{memberId}`
 
 operation::default/logout[snippets='http-request,http-response,request-headers,path-parameters,response-headers']
 

--- a/src/docs/asciidoc/MemberAddress-API.adoc
+++ b/src/docs/asciidoc/MemberAddress-API.adoc
@@ -3,24 +3,24 @@
 
 [[MemberAddress-register]]
 === 멤버 주소 등록
-`POST /address/register`
+`POST /member/address/register`
 
 operation::address/register[snippets='http-request,http-response,request-headers,request-fields']
 
 [[MemberAddress-view]]
 === 멤버 주소 조회
-`GET /address/view`
+`GET /member/address/view`
 
 operation::address/view[snippets='http-request,http-response,request-headers,response-fields']
 
 [[MemberAddress-delete]]
 === 멤버 주소 삭제
-`DELETE /address/{memberAddressId}`
+`DELETE /member/address/{memberAddressId}`
 
 operation::address[snippets='http-request,http-response,request-headers,path-parameters']
 
 [[MemberAddress-setHere]]
 === "요기" 위치 설정
-`PATCH /address/here/{memberAddressId}`
+`PATCH /member/address/here/{memberAddressId}`
 
 operation::address/here[snippets='http-request,http-response,request-headers,path-parameters']

--- a/src/docs/asciidoc/Menu-API.adoc
+++ b/src/docs/asciidoc/Menu-API.adoc
@@ -1,0 +1,8 @@
+[[Menu-API]]
+== Menu API
+
+[[Menu]]
+=== 음식 상세 정보 조회
+`GET /member/menu/{menu id}`
+
+operation::member/menu/details[snippets='http-request,http-response,path-parameters,response-fields']

--- a/src/docs/asciidoc/MenuGroup-API.adoc
+++ b/src/docs/asciidoc/MenuGroup-API.adoc
@@ -3,60 +3,56 @@
 
 [[MenuGroup]]
 === 메뉴 그룹 추가
-`POST /menu-group/add`
+`POST /owner/menu-group/add`
 
 operation::menu-group/add[snippets='http-request,http-response,request-headers,request-fields,response-fields']
 
 === 메뉴 그룹 전체 조회
-`GET /menu-group/shop/{shop id}`
+`GET /owner/menu-group/shop/{shop id}`
 
 operation::menu-group/find-all[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 메뉴 그룹 단건 조회
-`GET /menu-group/{menu group id}`
+`GET /owner/menu-group/{menu group id}`
 
 operation::menu-group/find-one[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 메뉴 그룹 정보 수정
-`PATCH /menu-group/{menu gorup id}`
+`PATCH /owner/menu-group/{menu gorup id}`
 
 operation::menu-group/update[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 메뉴 그룹 순서 변경
-`PUT /menu0group/shop/1/chenge-position`
+`PUT /owner/menu-group/shop/1/chenge-position`
 
 operation::menu-group/change-position[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 메뉴 그룹 메뉴 추가
-`POST /menu-group/{menu group id}/add-menu`
+`POST /owner/menu-group/{menu group id}/add-menu`
 
 operation::menu-group/add-menu[snippets='http-request,http-response,request-headers,path-parameters,request-parts,request-part-menuData-fields,response-fields']
 
 === 메뉴 그룹 메뉴 조회
-`GET /menu-group/{menu group id}/menu`
+`GET /owner/menu-group/{menu group id}/menu`
 
 operation::menu-group/find-menus[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 메뉴 그룹 메뉴 정보 수정
-`POST /menu-group/update-menu/{menu Id}`
+`POST /owner/menu-group/update-menu/{menu Id}`
 
 operation::menu-group/update-menu[snippets='http-request,http-response,request-headers,path-parameters,request-parts,request-part-menuData-fields']
 
 === 메뉴 그룹 삭제
-`DELETE /menu-group/{menu group id}`
+`DELETE /owner/menu-group/{menu group id}`
 
 operation::menu-group/delete[snippets='http-request,http-response,request-headers,path-parameters']
 
 === 메뉴 그룹 메뉴 삭제
-`DELETE /menu-group/delete-menu/{menu id}`
+`DELETE /owner/menu-group/delete-menu/{menu id}`
 
 operation::menu-group/delete-menu[snippets='http-request,http-response,request-headers,path-parameters']
 
 === 메뉴 그룹 메뉴 순서 변경
-`PATCH /menu-group/{menu group id}/change-menu-position`
+`PATCH /owner/menu-group/{menu group id}/change-menu-position`
 
 operation::menu-group/change-menu-position[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
-
-
-
-[[Menu]]

--- a/src/docs/asciidoc/MenuGroup-API.adoc
+++ b/src/docs/asciidoc/MenuGroup-API.adoc
@@ -56,3 +56,8 @@ operation::menu-group/delete-menu[snippets='http-request,http-response,request-h
 `PATCH /owner/menu-group/{menu group id}/change-menu-position`
 
 operation::menu-group/change-menu-position[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
+
+=== 메뉴 그룹 전체 조회 (가게 상세 페이지)
+`GET /member/menu-group/shop/{shop id}`
+
+operation::member/menu-group/find-all[snippets='http-request,http-response,path-parameters,response-fields']

--- a/src/docs/asciidoc/MenuOptionGroup-API.adoc
+++ b/src/docs/asciidoc/MenuOptionGroup-API.adoc
@@ -3,62 +3,62 @@
 
 [[Option-Group]]
 === 옵션 그룹 추가
-`POST /menu-option-group/shop/{shop id}/add`
+`POST /owner/menu-option-group/shop/{shop id}/add`
 
 operation::menu-option-group/add-group[snippets='http-request,http-response,request-headers,path-parameters,request-fields,response-fields']
 
 === 옵션 그룹 조회
-`GET /menu-option-group/{menu option group id`
+`GET /owner/menu-option-group/{menu option group id`
 
 operation::menu-option-group/find-one[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 옵션 그룹 전체 조회
-`GET /menu-option-group/shop/{shop id}`
+`GET /owner/menu-option-group/shop/{shop id}`
 
 operation::menu-option-group/find-all[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 옵션 그룹 수정
-`PATCH /menu-option-group/{menu option group id}/update`
+`PATCH /owner/menu-option-group/{menu option group id}/update`
 
 operation::menu-option-group/update[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 옵션 그룹 삭제
-`DELETE /menu-option-group/{menu option group id}/delete`
+`DELETE /owner/menu-option-group/{menu option group id}/delete`
 
 operation::menu-option-group/delete[snippets='http-request,http-response,request-headers,path-parameters']
 
 === 옵션 그룹 메뉴 연결
-`PUT /menu-option-group/{menu option group id}/link-menu`
+`PUT /owner/menu-option-group/{menu option group id}/link-menu`
 
 operation::menu-option-group/link-menu[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 옵션 그룹 정렬 순서 변경
-`PUT /menu-option-group/shop/{shop id}/change-position`
+`PUT /owner/menu-option-group/shop/{shop id}/change-position`
 
 operation::menu-option-group/change-position[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 [[Option]]
 === 옵션 추가
-`POST /menu-option-group/{menu option group id}/add-option`
+`POST /owner/menu-option-group/{menu option group id}/add-option`
 
 operation::menu-option-group/add-option[snippets='http-request,http-response,request-headers,path-parameters,request-fields,response-fields']
 
 === 옵션 조회
-`GET /menu-option-group/option/{menu option id}`
+`GET /owner/menu-option-group/option/{menu option id}`
 
 operation::menu-option-group/find-option[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 옵션 수정
-`PATCH /menu-option-group/option/{menu option id}/update`
+`PATCH /owner/menu-option-group/option/{menu option id}/update`
 
 operation::menu-option-group/update-option[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 옵션 삭제
-`DELETE /menu-option-group/option/{menu option id}/delete`
+`DELETE /owner/menu-option-group/option/{menu option id}/delete`
 
 operation::menu-option-group/delete-option[snippets='http-request,http-response,request-headers,path-parameters']
 
 === 옵션 정렬 순서 변경
-`PUT /menu-option-group/{menu option group id}/change-option-position`
+`PUT /owner/menu-option-group/{menu option group id}/change-option-position`
 
 operation::menu-option-group/change-option-position[snippets='http-request,http-response,request-headers,path-parameters,request-fields']

--- a/src/docs/asciidoc/Order-API.adoc
+++ b/src/docs/asciidoc/Order-API.adoc
@@ -3,18 +3,18 @@
 
 [[Order-create]]
 === 주문 생성
-`POST /order/create`
+`POST /member/order/create`
 
 operation::order/create[snippets='http-request,http-response,request-headers,request-fields']
 
 [[Order-scroll]]
 === 주문내역 조회
-`GET /order/scroll`
+`GET /member/order/scroll`
 
 operation::order/scroll[snippets='http-request,http-response,request-headers,request-parameters,response-fields']
 
 [[Order-detail]]
 === 상세 주문내역 조회
-`GET /order/details`
+`GET /member/order/details`
 
 operation::order/details[snippets='http-request,http-response,request-headers,request-parameters,response-fields']

--- a/src/docs/asciidoc/Owner-API.adoc
+++ b/src/docs/asciidoc/Owner-API.adoc
@@ -9,19 +9,19 @@ operation::owner/join[snippets='http-request,http-response,request-fields,respon
 
 [[Owner-default-login]]
 === 점주 기본 로그인
-`POST /ownerLogin`
+`POST /owner/login`
 
 operation::owner/default/login[snippets='http-request,http-response,request-fields,response-fields,response-headers']
 
 [[Owner-social-login]]
 === 점주 소셜 로그인
-`POST /ownerLogin`
+`POST /owner/login`
 
 operation::owner/social/login[snippets='http-request,http-response,request-fields,response-fields,response-headers']
 
 [[Owner-logout]]
 === 점주 로그아웃
-`POST /ownerLogout/{ownerId}`
+`POST /owner/logout/{ownerId}`
 
 operation::owner/default/logout[snippets='http-request,http-response,request-headers,path-parameters,response-headers']
 

--- a/src/docs/asciidoc/Review-API.adoc
+++ b/src/docs/asciidoc/Review-API.adoc
@@ -3,13 +3,13 @@
 
 [[Review-create]]
 === 리뷰 생성
-`POST /review/write`
+`POST /member/review/write`
 
 operation::review/write[snippets='http-request,http-response,request-headers,request-fields']
 
 [[Review-memberReview]]
 === 멤버 리뷰 조회
-`GET /review/memberReview`
+`GET /member/review/memberReview`
 
 operation::review/memberReview[snippets='http-request,http-response,request-headers,request-parameters,response-fields']
 

--- a/src/docs/asciidoc/Shop-API.adoc
+++ b/src/docs/asciidoc/Shop-API.adoc
@@ -2,67 +2,67 @@
 == Shop API
 
 === 입점
-`POST /shop/register`
+`POST /owner/shop/register`
 
 operation::shop/register[snippets='http-request,http-response,request-headers,request-parts,request-part-shopData-fields,response-fields']
 
 === 가게 정보 조회
-`GET /shop/{shop id}/info`
+`GET /owner/shop/{shop id}/info`
 
 operation::shop/get-info[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 상점 리스트 조회
-`GET /shop/list`
+`GET /owner/shop/list`
 
 operation::shop/list[snippets='http-request,http-response,request-parameters,response-fields']
 
 
 === 사장님 공지 조회
-`GET /shop/{shop id}/notice`
+`GET /owner/shop/{shop id}/notice`
 
 operation::shop/get-notice[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 영업 시간 조회
-`GET /shop/{shop id}/business-hours`
+`GET /owner/shop/{shop id}/business-hours`
 
 operation::shop/get-business-hours[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 배달 요금 조회
-`GET /shop/{shop id}/delivery-price`
+`GET /owner/shop/{shop id}/delivery-price`
 
 operation::shop/get-delivery-price[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 휴무일 조회
-`GET /shop/{shop id}/close-day`
+`GET /owner/shop/{shop id}/close-day`
 
 operation::shop/get-close-day[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 가게 정보 수정
-`PATCH /shop/{shop id}/call-number/update`
+`PATCH /owner/shop/{shop id}/call-number/update`
 
 operation::shop/update-call-number[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 사장님 공지 수정
-`POST /shop/{shop id}/notice/update`
+`POST /owner/shop/{shop id}/notice/update`
 
 operation::shop/update-notice[snippets='http-request,http-response,request-headers,path-parameters,request-parts,request-part-noticeData-fields']
 
 === 영업 시간 수정
-`PATCH /shop/{shop id}/business-hours/update`
+`PATCH /owner/shop/{shop id}/business-hours/update`
 
 operation::shop/update-business-hours[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 배달 요금 수정
-`PATCH /shop/{shop id}/delivery-price/udpate`
+`PATCH /owner/shop/{shop id}/delivery-price/udpate`
 
 operation::shop/update-delivery-price[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 휴무일 수정
-`PATCH /shop/{shop id}/close-day/update`
+`PATCH /owner/shop/{shop id}/close-day/update`
 
 operation::shop/update-close-day[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 가게 삭제
-`DELETE /shop/{shop id}/delete`
+`DELETE /owner/shop/{shop id}/delete`
 
 operation::shop/delete[snippets='http-request,http-response,request-headers,path-parameters']

--- a/src/docs/asciidoc/Shop-API.adoc
+++ b/src/docs/asciidoc/Shop-API.adoc
@@ -66,3 +66,8 @@ operation::shop/update-close-day[snippets='http-request,http-response,request-he
 `DELETE /owner/shop/{shop id}/delete`
 
 operation::shop/delete[snippets='http-request,http-response,request-headers,path-parameters']
+
+=== 가게 상세 정보 조회
+`GET /member/shop/details`
+
+operation::shop/details[snippets='http-request,http-response,request-parameters,response-fields']

--- a/src/docs/asciidoc/Shop-API.adoc
+++ b/src/docs/asciidoc/Shop-API.adoc
@@ -71,3 +71,8 @@ operation::shop/delete[snippets='http-request,http-response,request-headers,path
 `GET /member/shop/details`
 
 operation::shop/details[snippets='http-request,http-response,request-parameters,response-fields']
+
+=== 가게 원산지 정보 조회
+`GET /member/shop/{shop id}/info`
+
+operation::member/shop/info[snippets='http-request,http-response,path-parameters,request-parameters,response-fields']

--- a/src/docs/asciidoc/SignatureMenu-API.adoc
+++ b/src/docs/asciidoc/SignatureMenu-API.adoc
@@ -20,3 +20,8 @@ operation::signature-menu/change-position[snippets='http-request,http-response,r
 `DELETE /owner/signature-menu/delete/{menu id}`
 
 operation::signature-menu/delete-one[snippets='http-request,http-response,path-parameters']
+
+=== 대표 메뉴 전체 조회 (가게 상세 페이지)
+`GET /member/signature-menu/shop/{shop id}`
+
+operation::member/signature-menu/find-all[snippets='http-request,http-response,path-parameters,response-fields']

--- a/src/docs/asciidoc/SignatureMenu-API.adoc
+++ b/src/docs/asciidoc/SignatureMenu-API.adoc
@@ -2,21 +2,21 @@
 == Signature Menu API
 
 === 대표 메뉴 설정
-`PUT /signature-menu/set`
+`PUT /owner/signature-menu/set`
 
 operation::signature-menu/set[snippets='http-request,http-response,request-headers,request-fields']
 
 === 대표 메뉴 전체 조회
-`GET /signature-menu/shop/{shop id}`
+`GET /owner/signature-menu/shop/{shop id}`
 
 operation::signature-menu/find-all[snippets='http-request,http-response,path-parameters,response-fields']
 
 === 대표 메뉴 순서 변경
-`PUT /signature-menu/{shop id}/change-position`
+`PUT /owner/signature-menu/{shop id}/change-position`
 
 operation::signature-menu/change-position[snippets='http-request,http-response,request-headers,path-parameters,request-fields']
 
 === 대표 메뉴 삭제
-`DELETE /signature-menu/delete/{menu id}`
+`DELETE /owner/signature-menu/delete/{menu id}`
 
 operation::signature-menu/delete-one[snippets='http-request,http-response,path-parameters']

--- a/src/main/java/toy/yogiyo/api/member/LikeController.java
+++ b/src/main/java/toy/yogiyo/api/member/LikeController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/like")
+@RequestMapping("/member/like")
 public class LikeController {
 
     private final LikeService likeService;

--- a/src/main/java/toy/yogiyo/api/member/MemberAddressController.java
+++ b/src/main/java/toy/yogiyo/api/member/MemberAddressController.java
@@ -13,7 +13,7 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/address")
+@RequestMapping("/member/address")
 public class MemberAddressController {
 
     private final MemberAddressService memberAddressService;

--- a/src/main/java/toy/yogiyo/api/member/MenuController.java
+++ b/src/main/java/toy/yogiyo/api/member/MenuController.java
@@ -1,0 +1,22 @@
+package toy.yogiyo.api.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import toy.yogiyo.core.menu.dto.member.MenuDetailsGetResponse;
+import toy.yogiyo.core.menu.repository.MenuQueryRepository;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member/menu")
+public class MenuController {
+
+    private final MenuQueryRepository menuQueryRepository;
+
+    @GetMapping("/{menuId}")
+    public MenuDetailsGetResponse getDetails(@PathVariable Long menuId) {
+        return menuQueryRepository.getDetails(menuId);
+    }
+}

--- a/src/main/java/toy/yogiyo/api/member/MenuGroupController.java
+++ b/src/main/java/toy/yogiyo/api/member/MenuGroupController.java
@@ -1,0 +1,26 @@
+package toy.yogiyo.api.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import toy.yogiyo.core.menu.domain.MenuGroup;
+import toy.yogiyo.core.menu.dto.member.MenuGroupsGetResponse;
+import toy.yogiyo.core.menu.repository.MenuGroupRepository;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/member/menu-group")
+@RequiredArgsConstructor
+public class MenuGroupController {
+
+    private final MenuGroupRepository menuGroupRepository;
+
+    @GetMapping("/shop/{shopId}")
+    public MenuGroupsGetResponse getMenuGroups(@PathVariable Long shopId) {
+        List<MenuGroup> menuGroups = menuGroupRepository.findAllWithMenuByShopId(shopId);
+        return MenuGroupsGetResponse.from(menuGroups);
+    }
+}

--- a/src/main/java/toy/yogiyo/api/member/OrderController.java
+++ b/src/main/java/toy/yogiyo/api/member/OrderController.java
@@ -14,7 +14,7 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/order")
+@RequestMapping("/member/order")
 public class OrderController {
 
     private final OrderService orderService;

--- a/src/main/java/toy/yogiyo/api/member/ReviewController.java
+++ b/src/main/java/toy/yogiyo/api/member/ReviewController.java
@@ -13,7 +13,7 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/review")
+@RequestMapping("/member/review")
 public class ReviewController {
 
     private final ReviewService reviewService;

--- a/src/main/java/toy/yogiyo/api/member/ShopController.java
+++ b/src/main/java/toy/yogiyo/api/member/ShopController.java
@@ -2,8 +2,15 @@ package toy.yogiyo.api.member;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import toy.yogiyo.common.exception.AuthenticationException;
+import toy.yogiyo.common.exception.ErrorCode;
+import toy.yogiyo.common.login.LoginUser;
+import toy.yogiyo.core.member.domain.Member;
+import toy.yogiyo.core.shop.dto.ShopDetailsRequest;
+import toy.yogiyo.core.shop.dto.ShopDetailsResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListResponse;
+import toy.yogiyo.core.shop.repository.ShopRepository;
 import toy.yogiyo.core.shop.service.ShopService;
 
 import javax.validation.Valid;
@@ -15,10 +22,19 @@ import javax.validation.Valid;
 public class ShopController {
 
     private final ShopService shopService;
+    private final ShopRepository shopRepository;
 
     @GetMapping("/list")
     public ShopScrollListResponse getList(@Valid @ModelAttribute ShopScrollListRequest request){
         return shopService.getList(request);
+    }
+
+    @GetMapping("/details")
+    public ShopDetailsResponse getDetails(@LoginUser Member member,
+                                          @Valid @ModelAttribute ShopDetailsRequest request) {
+
+        if(member.getId() == null) throw new AuthenticationException(ErrorCode.MEMBER_UNAUTHORIZATION);
+        return shopRepository.details(member.getId(), request);
     }
 
 }

--- a/src/main/java/toy/yogiyo/api/member/ShopController.java
+++ b/src/main/java/toy/yogiyo/api/member/ShopController.java
@@ -8,6 +8,7 @@ import toy.yogiyo.common.login.LoginUser;
 import toy.yogiyo.core.member.domain.Member;
 import toy.yogiyo.core.shop.dto.ShopDetailsRequest;
 import toy.yogiyo.core.shop.dto.ShopDetailsResponse;
+import toy.yogiyo.core.shop.dto.member.ShopInfoResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListResponse;
 import toy.yogiyo.core.shop.repository.ShopRepository;
@@ -35,6 +36,11 @@ public class ShopController {
 
         if(member.getId() == null) throw new AuthenticationException(ErrorCode.MEMBER_UNAUTHORIZATION);
         return shopRepository.details(member.getId(), request);
+    }
+
+    @GetMapping("/{shopId}/info")
+    public ShopInfoResponse getInfo(@PathVariable Long shopId, @RequestParam String code) {
+        return shopRepository.info(shopId, code);
     }
 
 }

--- a/src/main/java/toy/yogiyo/api/member/ShopController.java
+++ b/src/main/java/toy/yogiyo/api/member/ShopController.java
@@ -1,105 +1,20 @@
 package toy.yogiyo.api.member;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import toy.yogiyo.common.login.LoginOwner;
-import toy.yogiyo.core.owner.domain.Owner;
-import toy.yogiyo.core.shop.dto.*;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListResponse;
 import toy.yogiyo.core.shop.service.ShopService;
 
 import javax.validation.Valid;
-import java.io.IOException;
-import java.util.List;
 
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/shop")
+@RequestMapping("/member/shop")
 public class ShopController {
 
     private final ShopService shopService;
-
-    @PostMapping(value = "/register")
-    @ResponseStatus(HttpStatus.CREATED)
-    public ShopRegisterResponse register(@LoginOwner Owner owner,
-                                         @Validated @RequestPart("shopData") ShopRegisterRequest request,
-                                         @RequestPart("icon") MultipartFile icon,
-                                         @RequestPart("banner") MultipartFile banner) throws IOException {
-
-        Long shopId = shopService.register(request, icon, banner, owner);
-
-        return ShopRegisterResponse.builder()
-                .id(shopId)
-                .build();
-    }
-
-    @GetMapping("/{shopId}/info")
-    public ShopInfoResponse getInfo(@PathVariable("shopId") Long shopId) {
-        return shopService.getInfo(shopId);
-    }
-    @GetMapping("/{shopId}/notice")
-    public ShopNoticeResponse getNotice(@PathVariable("shopId") Long shopId) {
-        return shopService.getNotice(shopId);
-    }
-    @GetMapping("/{shopId}/business-hours")
-    public ShopBusinessHourResponse getBusinessHours(@PathVariable("shopId") Long shopId) {
-        return shopService.getBusinessHours(shopId);
-    }
-
-    @GetMapping("/{shopId}/close-day")
-    public ShopCloseDayResponse getCloseDays(@PathVariable Long shopId) {
-        return shopService.getCloseDays(shopId);
-    }
-
-    @PatchMapping("/{shopId}/call-number/update")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateCallNumber(@LoginOwner Owner owner,
-                             @PathVariable Long shopId,
-                             @Validated @RequestBody ShopUpdateCallNumberRequest request) {
-
-        shopService.updateCallNumber(shopId, owner, request);
-    }
-
-    @PostMapping("/{shopId}/notice/update")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateNotice(@LoginOwner Owner owner,
-                               @PathVariable Long shopId,
-                               @Validated @RequestPart("noticeData") ShopNoticeUpdateRequest request,
-                               @RequestPart(value = "images", required = false) List<MultipartFile> imageFiles) throws IOException {
-
-        shopService.updateNotice(shopId, owner, request, imageFiles);
-    }
-
-    @PatchMapping("/{shopId}/business-hours/update")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateBusinessHours(@LoginOwner Owner owner,
-                                    @PathVariable Long shopId,
-                                    @Validated @RequestBody ShopBusinessHourUpdateRequest request) {
-
-        shopService.updateBusinessHours(shopId, owner, request);
-    }
-
-
-    @PatchMapping("/{shopId}/close-day/update")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateCloseDays(@LoginOwner Owner owner,
-                                @PathVariable Long shopId,
-                                @Validated @RequestBody ShopCloseDayUpdateRequest request) {
-
-        shopService.updateCloseDays(shopId, owner, request);
-    }
-
-
-    @DeleteMapping("/{shopId}/delete")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@LoginOwner Owner owner, @PathVariable("shopId") Long shopId) {
-        shopService.delete(shopId, owner);
-    }
 
     @GetMapping("/list")
     public ShopScrollListResponse getList(@Valid @ModelAttribute ShopScrollListRequest request){

--- a/src/main/java/toy/yogiyo/api/member/SignatureMenuController.java
+++ b/src/main/java/toy/yogiyo/api/member/SignatureMenuController.java
@@ -1,0 +1,29 @@
+package toy.yogiyo.api.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import toy.yogiyo.core.menu.domain.SignatureMenu;
+import toy.yogiyo.core.menu.dto.SignatureMenuSetRequest;
+import toy.yogiyo.core.menu.dto.SignatureMenuUpdatePositionRequest;
+import toy.yogiyo.core.menu.dto.SignatureMenusResponse;
+import toy.yogiyo.core.menu.service.SignatureMenuService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/member/signature-menu")
+@RequiredArgsConstructor
+public class SignatureMenuController {
+
+    private final SignatureMenuService signatureMenuService;
+
+    @GetMapping("/shop/{shopId}")
+    public SignatureMenusResponse getSignatureMenus(@PathVariable Long shopId) {
+        List<SignatureMenu> signatureMenus = signatureMenuService.getAll(shopId);
+        return SignatureMenusResponse.from(signatureMenus);
+    }
+
+}

--- a/src/main/java/toy/yogiyo/api/owner/DeliveryPlaceController.java
+++ b/src/main/java/toy/yogiyo/api/owner/DeliveryPlaceController.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,7 +13,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/delivery-place")
+@RequestMapping("/owner/delivery-place")
 public class DeliveryPlaceController {
 
     private final DeliveryPlaceService deliveryPlaceService;

--- a/src/main/java/toy/yogiyo/api/owner/MenuGroupController.java
+++ b/src/main/java/toy/yogiyo/api/owner/MenuGroupController.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,14 +15,13 @@ import toy.yogiyo.core.menu.service.MenuService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/menu-group")
+@RequestMapping("/owner/menu-group")
 @RequiredArgsConstructor
 public class MenuGroupController {
 
     private final MenuGroupService menuGroupService;
     private final MenuService menuService;
 
-    // =================== 점주 기능 ======================
     @PostMapping("/add")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("@shopPermissionEvaluator.hasWritePermission(authentication, #request.shopId)")
@@ -122,7 +121,5 @@ public class MenuGroupController {
         List<Menu> menus = request.toMenus();
         menuGroupService.updateMenuPosition(menuGroupId, menus);
     }
-
-    // =================== 고객 기능 ======================
 
 }

--- a/src/main/java/toy/yogiyo/api/owner/MenuGroupController.java
+++ b/src/main/java/toy/yogiyo/api/owner/MenuGroupController.java
@@ -3,6 +3,7 @@ package toy.yogiyo.api.owner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,7 @@ import toy.yogiyo.core.menu.service.MenuService;
 
 import java.util.List;
 
+@Component("menuGroupOwnerController")
 @RestController
 @RequestMapping("/owner/menu-group")
 @RequiredArgsConstructor

--- a/src/main/java/toy/yogiyo/api/owner/MenuOptionGroupController.java
+++ b/src/main/java/toy/yogiyo/api/owner/MenuOptionGroupController.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/menu-option-group")
+@RequestMapping("/owner/menu-option-group")
 public class MenuOptionGroupController {
 
     private final MenuOptionGroupService menuOptionGroupService;

--- a/src/main/java/toy/yogiyo/api/owner/ReviewManagementController.java
+++ b/src/main/java/toy/yogiyo/api/owner/ReviewManagementController.java
@@ -14,7 +14,7 @@ import toy.yogiyo.core.review.service.ReviewManagementService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/management/review")
+@RequestMapping("/owner/review")
 public class ReviewManagementController {
 
     private final ReviewQueryRepository reviewQueryRepository;

--- a/src/main/java/toy/yogiyo/api/owner/ShopController.java
+++ b/src/main/java/toy/yogiyo/api/owner/ShopController.java
@@ -1,0 +1,99 @@
+package toy.yogiyo.api.owner;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import toy.yogiyo.common.login.LoginOwner;
+import toy.yogiyo.core.owner.domain.Owner;
+import toy.yogiyo.core.shop.dto.*;
+import toy.yogiyo.core.shop.service.ShopService;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/owner/shop")
+public class ShopController {
+
+    private final ShopService shopService;
+
+    @PostMapping(value = "/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ShopRegisterResponse register(@LoginOwner Owner owner,
+                                         @Validated @RequestPart("shopData") ShopRegisterRequest request,
+                                         @RequestPart("icon") MultipartFile icon,
+                                         @RequestPart("banner") MultipartFile banner) {
+
+        Long shopId = shopService.register(request, icon, banner, owner);
+
+        return ShopRegisterResponse.builder()
+                .id(shopId)
+                .build();
+    }
+
+    @GetMapping("/{shopId}/info")
+    public ShopInfoResponse getInfo(@PathVariable("shopId") Long shopId) {
+        return shopService.getInfo(shopId);
+    }
+    @GetMapping("/{shopId}/notice")
+    public ShopNoticeResponse getNotice(@PathVariable("shopId") Long shopId) {
+        return shopService.getNotice(shopId);
+    }
+    @GetMapping("/{shopId}/business-hours")
+    public ShopBusinessHourResponse getBusinessHours(@PathVariable("shopId") Long shopId) {
+        return shopService.getBusinessHours(shopId);
+    }
+
+    @GetMapping("/{shopId}/close-day")
+    public ShopCloseDayResponse getCloseDays(@PathVariable Long shopId) {
+        return shopService.getCloseDays(shopId);
+    }
+
+    @PatchMapping("/{shopId}/call-number/update")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateCallNumber(@LoginOwner Owner owner,
+                                 @PathVariable Long shopId,
+                                 @Validated @RequestBody ShopUpdateCallNumberRequest request) {
+
+        shopService.updateCallNumber(shopId, owner, request);
+    }
+
+    @PostMapping("/{shopId}/notice/update")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateNotice(@LoginOwner Owner owner,
+                             @PathVariable Long shopId,
+                             @Validated @RequestPart("noticeData") ShopNoticeUpdateRequest request,
+                             @RequestPart(value = "images", required = false) List<MultipartFile> imageFiles) throws IOException {
+
+        shopService.updateNotice(shopId, owner, request, imageFiles);
+    }
+
+    @PatchMapping("/{shopId}/business-hours/update")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateBusinessHours(@LoginOwner Owner owner,
+                                    @PathVariable Long shopId,
+                                    @Validated @RequestBody ShopBusinessHourUpdateRequest request) {
+
+        shopService.updateBusinessHours(shopId, owner, request);
+    }
+
+
+    @PatchMapping("/{shopId}/close-day/update")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateCloseDays(@LoginOwner Owner owner,
+                                @PathVariable Long shopId,
+                                @Validated @RequestBody ShopCloseDayUpdateRequest request) {
+
+        shopService.updateCloseDays(shopId, owner, request);
+    }
+
+
+    @DeleteMapping("/{shopId}/delete")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@LoginOwner Owner owner, @PathVariable("shopId") Long shopId) {
+        shopService.delete(shopId, owner);
+    }
+}

--- a/src/main/java/toy/yogiyo/api/owner/ShopController.java
+++ b/src/main/java/toy/yogiyo/api/owner/ShopController.java
@@ -2,6 +2,7 @@ package toy.yogiyo.api.owner;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,6 +14,7 @@ import toy.yogiyo.core.shop.service.ShopService;
 import java.io.IOException;
 import java.util.List;
 
+@Component("shopOwnerController")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/owner/shop")

--- a/src/main/java/toy/yogiyo/api/owner/SignatureMenuController.java
+++ b/src/main/java/toy/yogiyo/api/owner/SignatureMenuController.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -14,7 +14,7 @@ import toy.yogiyo.core.menu.service.SignatureMenuService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/signature-menu")
+@RequestMapping("/owner/signature-menu")
 @RequiredArgsConstructor
 public class SignatureMenuController {
 

--- a/src/main/java/toy/yogiyo/api/owner/SignatureMenuController.java
+++ b/src/main/java/toy/yogiyo/api/owner/SignatureMenuController.java
@@ -3,6 +3,7 @@ package toy.yogiyo.api.owner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import toy.yogiyo.core.menu.domain.SignatureMenu;
@@ -13,6 +14,7 @@ import toy.yogiyo.core.menu.service.SignatureMenuService;
 
 import java.util.List;
 
+@Component("signatureMenuOwnerController")
 @RestController
 @RequestMapping("/owner/signature-menu")
 @RequiredArgsConstructor

--- a/src/main/java/toy/yogiyo/common/login/LoginController.java
+++ b/src/main/java/toy/yogiyo/common/login/LoginController.java
@@ -28,7 +28,7 @@ public class LoginController {
     private final LoginService loginService;
     private final JwtProvider jwtProvider;
 
-    @PostMapping("/memberLogin")
+    @PostMapping("/member/login")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<LoginResponse> memberLogin(@RequestBody LoginRequest loginRequest){
 
@@ -41,7 +41,7 @@ public class LoginController {
         return new ResponseEntity<>(loginResponse, headers, HttpStatus.OK);
     }
 
-    @PostMapping("/memberLogout/{memberId}")
+    @PostMapping("/member/logout/{memberId}")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<String> memberLogout(@LoginUser Member member, @PathVariable Long memberId){
         if(!member.getId().equals(memberId)) throw new AuthenticationException(ErrorCode.MEMBER_UNAUTHORIZATION);
@@ -51,7 +51,7 @@ public class LoginController {
         return new ResponseEntity<>("멤버 로그아웃 완료", headers, HttpStatus.OK);
     }
 
-    @PostMapping("/ownerLogin")
+    @PostMapping("/owner/login")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<LoginResponse> ownerLogin(@RequestBody LoginRequest loginRequest){
 
@@ -64,7 +64,7 @@ public class LoginController {
         return new ResponseEntity<>(loginResponse, headers, HttpStatus.OK);
     }
 
-    @PostMapping("/ownerLogout/{ownerId}")
+    @PostMapping("/owner/logout/{ownerId}")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<String> ownerLogout(@LoginOwner Owner owner, @PathVariable Long ownerId){
         if(!owner.getId().equals(ownerId)) throw new AuthenticationException(ErrorCode.MEMBER_UNAUTHORIZATION);

--- a/src/main/java/toy/yogiyo/core/menu/domain/Menu.java
+++ b/src/main/java/toy/yogiyo/core/menu/domain/Menu.java
@@ -28,6 +28,8 @@ public class Menu {
 
     private Integer position;
 
+    private long reviewNum;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_group_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private MenuGroup menuGroup;
@@ -54,4 +56,12 @@ public class Menu {
         this.menuGroup = menuGroup;
     }
 
+
+    public void decreaseReviewNum() {
+        this.reviewNum--;
+    }
+
+    public void increaseReviewNum() {
+        this.reviewNum++;
+    }
 }

--- a/src/main/java/toy/yogiyo/core/menu/dto/member/MenuDetailsGetResponse.java
+++ b/src/main/java/toy/yogiyo/core/menu/dto/member/MenuDetailsGetResponse.java
@@ -1,0 +1,56 @@
+package toy.yogiyo.core.menu.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.repository.NoRepositoryBean;
+import toy.yogiyo.core.menuoption.domain.OptionType;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuDetailsGetResponse {
+
+    private Long id;
+    private String name;
+    private String content;
+    private String picture;
+    private int price;
+    private long reviewNum;
+    private List<OptionGroupDto> optionGroups;
+
+    public void setOptionGroups(List<OptionGroupDto> optionGroups) {
+        this.optionGroups = optionGroups;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionGroupDto {
+
+        private Long id;
+        private String name;
+        private int count;
+        private boolean isPossibleCount;
+        private OptionType optionType;
+        private List<OptionDto> options;
+
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionDto {
+
+        private Long id;
+        private String content;
+        private int price;
+
+    }
+}

--- a/src/main/java/toy/yogiyo/core/menu/dto/member/MenuGroupsGetResponse.java
+++ b/src/main/java/toy/yogiyo/core/menu/dto/member/MenuGroupsGetResponse.java
@@ -1,0 +1,63 @@
+package toy.yogiyo.core.menu.dto.member;
+
+import lombok.Builder;
+import lombok.Getter;
+import toy.yogiyo.core.menu.domain.Menu;
+import toy.yogiyo.core.menu.domain.MenuGroup;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MenuGroupsGetResponse {
+
+    private List<MenuGroupDto> menuGroups;
+
+    public static MenuGroupsGetResponse from(List<MenuGroup> menuGroups) {
+        return MenuGroupsGetResponse.builder()
+                .menuGroups(menuGroups.stream()
+                        .map(MenuGroupDto::new)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    @Getter
+    private static class MenuGroupDto {
+
+        private Long id;
+        private String name;
+        private String content;
+        private List<MenuDto> menus;
+
+        public MenuGroupDto(MenuGroup menuGroup) {
+            this.id = menuGroup.getId();
+            this.name = menuGroup.getName();
+            this.content = menuGroup.getContent();
+            this.menus = menuGroup.getMenus().stream()
+                    .map(MenuDto::new)
+                    .collect(Collectors.toList());
+        }
+
+    }
+
+    @Getter
+    private static class MenuDto {
+        private Long id;
+        private String name;
+        private String content;
+        private int price;
+        private long reviewNum;
+        private String picture;
+
+        public MenuDto(Menu menu) {
+            this.id = menu.getId();
+            this.name = menu.getName();
+            this.content = menu.getContent();
+            this.price = menu.getPrice();
+            this.reviewNum = menu.getReviewNum();
+            this.picture = menu.getPicture();
+        }
+    }
+
+}

--- a/src/main/java/toy/yogiyo/core/menu/repository/MenuQueryRepository.java
+++ b/src/main/java/toy/yogiyo/core/menu/repository/MenuQueryRepository.java
@@ -1,0 +1,65 @@
+package toy.yogiyo.core.menu.repository;
+
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+import toy.yogiyo.core.menu.dto.member.MenuDetailsGetResponse;
+
+import javax.persistence.EntityManager;
+
+import java.util.List;
+
+import static toy.yogiyo.core.menu.domain.QMenu.menu;
+import static toy.yogiyo.core.menuoption.domain.QMenuOption.menuOption;
+import static toy.yogiyo.core.menuoption.domain.QMenuOptionGroup.menuOptionGroup;
+import static toy.yogiyo.core.menuoption.domain.QOptionGroupLinkMenu.optionGroupLinkMenu;
+
+@Repository
+public class MenuQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MenuQueryRepository(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    public MenuDetailsGetResponse getDetails(Long menuId) {
+        MenuDetailsGetResponse response = queryFactory.select(Projections.fields(MenuDetailsGetResponse.class,
+                        menu.id,
+                        menu.content,
+                        menu.name,
+                        menu.picture,
+                        menu.price,
+                        menu.reviewNum
+                ))
+                .from(menu)
+                .where(menu.id.eq(menuId))
+                .fetchOne();
+
+        List<MenuDetailsGetResponse.OptionGroupDto> optionGroups = queryFactory
+                .from(optionGroupLinkMenu)
+                .join(optionGroupLinkMenu.menuOptionGroup, menuOptionGroup)
+                .join(menuOptionGroup.menuOptions, menuOption)
+                .where(optionGroupLinkMenu.menu.id.eq(menuId))
+                .orderBy(menuOptionGroup.position.asc(), menuOption.position.asc())
+                .transform(GroupBy.groupBy(menuOptionGroup.id).list(
+                        Projections.fields(MenuDetailsGetResponse.OptionGroupDto.class,
+                                menuOptionGroup.id,
+                                menuOptionGroup.name,
+                                menuOptionGroup.count,
+                                menuOptionGroup.isPossibleCount,
+                                menuOptionGroup.optionType,
+                                GroupBy.list(Projections.fields(MenuDetailsGetResponse.OptionDto.class,
+                                        menuOption.id,
+                                        menuOption.content,
+                                        menuOption.price
+                                )).as("options")
+                        )
+                ));
+
+        response.setOptionGroups(optionGroups);
+
+        return response;
+    }
+}

--- a/src/main/java/toy/yogiyo/core/menu/repository/MenuRepository.java
+++ b/src/main/java/toy/yogiyo/core/menu/repository/MenuRepository.java
@@ -15,4 +15,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Query("select m from Menu m where m.menuGroup.id = :menuGroupId order by m.position asc")
     List<Menu> findMenus(@Param("menuGroupId") Long menuGroupId);
+
+    @Query("select m from Menu m where m.id in :menuIds")
+    List<Menu> findMenus(@Param("menuIds") Long[] menuIds);
 }

--- a/src/main/java/toy/yogiyo/core/order/domain/OrderItem.java
+++ b/src/main/java/toy/yogiyo/core/order/domain/OrderItem.java
@@ -3,6 +3,7 @@ package toy.yogiyo.core.order.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import toy.yogiyo.common.domain.BaseTimeEntity;
+import toy.yogiyo.core.menu.domain.Menu;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ public class OrderItem extends BaseTimeEntity {
     private int price;
     private int quantity;
     private String menuName;
+    private Long menuId;
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,12 +33,13 @@ public class OrderItem extends BaseTimeEntity {
     private List<OrderItemOption> orderItemOptions = new ArrayList<>();
 
     @Builder
-    public OrderItem(Long id, int price, int quantity, String menuName, List<OrderItemOption> orderItemOptions) {
+    public OrderItem(Long id, int price, int quantity, String menuName, List<OrderItemOption> orderItemOptions, Long menuId) {
         this.id = id;
         this.price = price;
         this.quantity = quantity;
         this.menuName = menuName;
         this.orderItemOptions = orderItemOptions;
+        this.menuId = menuId;
     }
 
 

--- a/src/main/java/toy/yogiyo/core/review/service/ReviewService.java
+++ b/src/main/java/toy/yogiyo/core/review/service/ReviewService.java
@@ -2,10 +2,14 @@ package toy.yogiyo.core.review.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import toy.yogiyo.common.exception.EntityNotFoundException;
 import toy.yogiyo.common.exception.ErrorCode;
 import toy.yogiyo.core.member.domain.Member;
+import toy.yogiyo.core.menu.domain.Menu;
+import toy.yogiyo.core.menu.repository.MenuRepository;
 import toy.yogiyo.core.order.domain.Order;
+import toy.yogiyo.core.order.domain.OrderItem;
 import toy.yogiyo.core.order.repository.OrderRepository;
 import toy.yogiyo.core.review.domain.Review;
 import toy.yogiyo.core.review.dto.MemberReviewScrollResponse;
@@ -17,6 +21,7 @@ import toy.yogiyo.core.shop.domain.Shop;
 import toy.yogiyo.core.shop.repository.ShopRepository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +30,9 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final OrderRepository orderRepository;
     private final ShopRepository shopRepository;
+    private final MenuRepository menuRepository;
 
+    @Transactional
     public void create(Member member, ReviewCreateRequest request){
         Order order = orderRepository.findById(request.getOrderId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ORDER_NOT_FOUND));
@@ -33,6 +40,15 @@ public class ReviewService {
         Shop shop = shopRepository.findById(request.getShopId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SHOP_NOT_FOUND));
         shop.addReview(review);
+
+        Long[] menuIds = order.getOrderItems().stream()
+                .map(OrderItem::getMenuId)
+                .toArray(Long[]::new);
+        List<Menu> menus = menuRepository.findMenus(menuIds);
+        for (Menu menu : menus) {
+            menu.increaseReviewNum();
+        }
+
         reviewRepository.save(review);
     }
 

--- a/src/main/java/toy/yogiyo/core/shop/dto/ShopDetailsRequest.java
+++ b/src/main/java/toy/yogiyo/core/shop/dto/ShopDetailsRequest.java
@@ -1,0 +1,20 @@
+package toy.yogiyo.core.shop.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+public class ShopDetailsRequest {
+    @NotNull
+    private Long shopId;
+    @NotNull
+    private String code;
+    @NotNull
+    private Double latitude;
+    @NotNull
+    private Double longitude;
+}

--- a/src/main/java/toy/yogiyo/core/shop/dto/ShopDetailsResponse.java
+++ b/src/main/java/toy/yogiyo/core/shop/dto/ShopDetailsResponse.java
@@ -18,6 +18,7 @@ public class ShopDetailsResponse {
     private Long likeNum;
     private BigDecimal totalScore;
     private String banner;
+    private String noticeTitle;
     private Double distance;
     private Integer minOrderPrice;
     private Integer minDeliveryPrice;

--- a/src/main/java/toy/yogiyo/core/shop/dto/ShopDetailsResponse.java
+++ b/src/main/java/toy/yogiyo/core/shop/dto/ShopDetailsResponse.java
@@ -1,0 +1,25 @@
+package toy.yogiyo.core.shop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShopDetailsResponse {
+    private Long id;
+    private String name;
+    private Long reviewNum;
+    private Long likeNum;
+    private BigDecimal totalScore;
+    private String banner;
+    private Double distance;
+    private Integer minOrderPrice;
+    private Integer minDeliveryPrice;
+    private Boolean isLike;
+}

--- a/src/main/java/toy/yogiyo/core/shop/dto/member/ShopInfoResponse.java
+++ b/src/main/java/toy/yogiyo/core/shop/dto/member/ShopInfoResponse.java
@@ -1,0 +1,61 @@
+package toy.yogiyo.core.shop.dto.member;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import toy.yogiyo.core.shop.domain.Days;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShopInfoResponse {
+
+    private Long id;
+    private String name;
+    private String noticeTitle;
+    private String ownerNotice;
+    private List<String> noticeImages;
+//    private String noticeImages;
+    private String callNumber;
+    private String address;
+    private List<DeliveryPriceInfoDto> deliveryPriceInfos;
+    private List<BusinessHoursDto> businessHours;
+
+    public void setBusinessHours(List<BusinessHoursDto> businessHours) {
+        this.businessHours = businessHours;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeliveryPriceInfoDto {
+
+        private Long id;
+        private int deliveryPrice;
+        private int orderPrice;
+
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BusinessHoursDto {
+
+        private Long id;
+        private LocalTime breakTimeStart;
+        private LocalTime breakTimeEnd;
+        private LocalTime openTime;
+        private LocalTime closeTime;
+        private Days dayOfWeek;
+        private boolean isOpen;
+
+    }
+}

--- a/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepository.java
+++ b/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepository.java
@@ -2,6 +2,8 @@ package toy.yogiyo.core.shop.repository;
 
 import toy.yogiyo.core.like.dto.LikeResponse;
 import toy.yogiyo.core.like.dto.LikeScrollRequest;
+import toy.yogiyo.core.shop.dto.ShopDetailsRequest;
+import toy.yogiyo.core.shop.dto.ShopDetailsResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollResponse;
 
@@ -10,4 +12,6 @@ import java.util.List;
 public interface ShopCustomRepository {
     List<LikeResponse> scrollLikes(Long memberId, LikeScrollRequest request);
     List<ShopScrollResponse> scrollShopList(ShopScrollListRequest request);
+
+    ShopDetailsResponse details(Long memberId, ShopDetailsRequest request);
 }

--- a/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepository.java
+++ b/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepository.java
@@ -4,6 +4,7 @@ import toy.yogiyo.core.like.dto.LikeResponse;
 import toy.yogiyo.core.like.dto.LikeScrollRequest;
 import toy.yogiyo.core.shop.dto.ShopDetailsRequest;
 import toy.yogiyo.core.shop.dto.ShopDetailsResponse;
+import toy.yogiyo.core.shop.dto.member.ShopInfoResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollResponse;
 
@@ -14,4 +15,6 @@ public interface ShopCustomRepository {
     List<ShopScrollResponse> scrollShopList(ShopScrollListRequest request);
 
     ShopDetailsResponse details(Long memberId, ShopDetailsRequest request);
+
+    ShopInfoResponse info(Long shopId, String code);
 }

--- a/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepositoryImpl.java
+++ b/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package toy.yogiyo.core.shop.repository;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
@@ -11,10 +12,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import toy.yogiyo.core.deliveryplace.domain.QDeliveryPlace;
+import toy.yogiyo.core.deliveryplace.domain.QDeliveryPriceInfo;
 import toy.yogiyo.core.like.dto.LikeResponse;
 import toy.yogiyo.core.like.dto.LikeScrollRequest;
+import toy.yogiyo.core.shop.domain.QBusinessHours;
 import toy.yogiyo.core.shop.dto.ShopDetailsRequest;
 import toy.yogiyo.core.shop.dto.ShopDetailsResponse;
+import toy.yogiyo.core.shop.dto.member.ShopInfoResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollResponse;
 
@@ -25,7 +29,9 @@ import static java.time.LocalTime.now;
 import static toy.yogiyo.core.category.domain.QCategory.category;
 import static toy.yogiyo.core.category.domain.QCategoryShop.categoryShop;
 import static toy.yogiyo.core.deliveryplace.domain.QDeliveryPlace.deliveryPlace;
+import static toy.yogiyo.core.deliveryplace.domain.QDeliveryPriceInfo.deliveryPriceInfo;
 import static toy.yogiyo.core.like.domain.QLike.like;
+import static toy.yogiyo.core.shop.domain.QBusinessHours.businessHours;
 import static toy.yogiyo.core.shop.domain.QShop.shop;
 
 @Repository
@@ -34,6 +40,46 @@ import static toy.yogiyo.core.shop.domain.QShop.shop;
 public class ShopCustomRepositoryImpl implements ShopCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public ShopInfoResponse info(Long shopId, String code) {
+        ShopInfoResponse result = jpaQueryFactory.from(shop)
+                .join(deliveryPlace).on(deliveryPlace.shop.id.eq(shop.id))
+                .join(deliveryPriceInfo).on(deliveryPriceInfo.deliveryPlace.id.eq(deliveryPlace.id).and(deliveryPlace.code.eq(code)))
+                .where(shop.id.eq(shopId))
+                .transform(GroupBy.groupBy(shop.id).list(
+                        Projections.fields(ShopInfoResponse.class,
+                                shop.id,
+                                shop.name,
+                                shop.noticeTitle,
+                                shop.ownerNotice,
+                                shop.noticeImages,
+                                shop.callNumber,
+                                shop.address,
+                                GroupBy.list(Projections.fields(ShopInfoResponse.DeliveryPriceInfoDto.class,
+                                        deliveryPriceInfo.id,
+                                        deliveryPriceInfo.deliveryPrice,
+                                        deliveryPriceInfo.orderPrice
+                                )).as("deliveryPriceInfos")
+                        )
+                )).get(0);
+
+        List<ShopInfoResponse.BusinessHoursDto> bh = jpaQueryFactory.select(Projections.fields(ShopInfoResponse.BusinessHoursDto.class,
+                        businessHours.id,
+                        businessHours.breakTimeStart,
+                        businessHours.breakTimeEnd,
+                        businessHours.openTime,
+                        businessHours.closeTime,
+                        businessHours.dayOfWeek,
+                        businessHours.isOpen))
+                .from(businessHours)
+                .where(businessHours.shop.id.eq(shopId))
+                .fetch();
+
+        result.setBusinessHours(bh);
+
+        return result;
+    }
 
     @Override
     public ShopDetailsResponse details(Long memberId, ShopDetailsRequest request) {

--- a/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepositoryImpl.java
+++ b/src/main/java/toy/yogiyo/core/shop/repository/ShopCustomRepositoryImpl.java
@@ -44,6 +44,7 @@ public class ShopCustomRepositoryImpl implements ShopCustomRepository {
                         shop.likeNum,
                         shop.totalScore,
                         shop.banner,
+                        shop.noticeTitle,
                         getShopDistance(request.getLatitude(), request.getLongitude()).as("distance"),
                         deliveryPlace.minOrderPrice,
                         deliveryPlace.minDeliveryPrice,

--- a/src/test/java/toy/yogiyo/api/member/DeliveryPlaceControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/DeliveryPlaceControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import toy.yogiyo.api.member.DeliveryPlaceController;
+import toy.yogiyo.api.owner.DeliveryPlaceController;
 import toy.yogiyo.common.security.WithLoginOwner;
 import toy.yogiyo.core.deliveryplace.domain.DeliveryPlace;
 import toy.yogiyo.core.deliveryplace.domain.DeliveryPriceInfo;
@@ -83,7 +83,7 @@ class DeliveryPlaceControllerTest {
                 .build();
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/delivery-place/shop/{shopId}/add", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/owner/delivery-place/shop/{shopId}/add", 1)
                 .header(HttpHeaders.AUTHORIZATION, jwt)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsBytes(request)));
@@ -114,7 +114,7 @@ class DeliveryPlaceControllerTest {
         doNothing().when(deliveryPlaceService).delete(anyLong());
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/delivery-place/{deliveryPlaceId}/delete", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/delivery-place/{deliveryPlaceId}/delete", 1)
                 .header(HttpHeaders.AUTHORIZATION, jwt));
 
         // then
@@ -145,7 +145,7 @@ class DeliveryPlaceControllerTest {
                 .build();
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/delivery-place/{deliveryPlaceId}/delivery-price/update", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/delivery-place/{deliveryPlaceId}/delivery-price/update", 1)
                 .header(HttpHeaders.AUTHORIZATION, jwt)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
@@ -183,7 +183,7 @@ class DeliveryPlaceControllerTest {
                 .build();
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/delivery-place/shop/{shopId}/delivery-price/update", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/delivery-place/shop/{shopId}/delivery-price/update", 1)
                 .header(HttpHeaders.AUTHORIZATION, jwt)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
@@ -220,7 +220,7 @@ class DeliveryPlaceControllerTest {
                 .build());
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/delivery-place/{deliveryPlaceId}/delivery-price", 1));
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/delivery-place/{deliveryPlaceId}/delivery-price", 1));
 
         // then
         result.andExpect(status().isOk())

--- a/src/test/java/toy/yogiyo/api/member/LikeControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/LikeControllerTest.java
@@ -67,7 +67,7 @@ class LikeControllerTest {
     void toggleLike() throws Exception {
         doNothing().when(likeService).toggleLike(any(), any());
 
-        mockMvc.perform(post("/like/{shopId}", 1L)
+        mockMvc.perform(post("/member/like/{shopId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", jwt)
                 )
@@ -113,7 +113,7 @@ class LikeControllerTest {
 
         given(likeService.getLikes(any(), any())).willReturn(likeResponses);
 
-        mockMvc.perform(get("/like/scroll")
+        mockMvc.perform(get("/member/like/scroll")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("offset", "")
                         .param("limit", "2")
@@ -169,7 +169,7 @@ class LikeControllerTest {
 
         given(likeService.getLikes(any())).willReturn(likeResponse);
 
-        mockMvc.perform(get("/like/list")
+        mockMvc.perform(get("/member/like/list")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", jwt)
                 )

--- a/src/test/java/toy/yogiyo/api/member/MemberAddressControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/MemberAddressControllerTest.java
@@ -84,7 +84,7 @@ class MemberAddressControllerTest {
 
         doNothing().when(memberAddressService).register(any(), any());
 
-        mockMvc.perform(post("/address/register")
+        mockMvc.perform(post("/member/address/register")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", jwt)
                 .content(objectMapper.writeValueAsString(request))
@@ -143,7 +143,7 @@ class MemberAddressControllerTest {
 
         given(memberAddressService.getAddresses(any())).willReturn(response);
 
-        mockMvc.perform(get("/address/view")
+        mockMvc.perform(get("/member/address/view")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", jwt)
                 )
@@ -175,7 +175,7 @@ class MemberAddressControllerTest {
 
         doNothing().when(memberAddressService).delete(any(), any());
 
-        mockMvc.perform(delete("/address/{memberAddressId}", 1L)
+        mockMvc.perform(delete("/member/address/{memberAddressId}", 1L)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", jwt))
                 .andExpect(status().isNoContent())
@@ -197,7 +197,7 @@ class MemberAddressControllerTest {
     void setHere() throws Exception {
         doNothing().when(memberAddressService).setHere(any(), any());
 
-        mockMvc.perform(patch("/address/here/{memberAddressId}", 1L)
+        mockMvc.perform(patch("/member/address/here/{memberAddressId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", jwt))
                 .andExpect(status().isNoContent())

--- a/src/test/java/toy/yogiyo/api/member/MenuControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/MenuControllerTest.java
@@ -1,0 +1,174 @@
+package toy.yogiyo.api.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import toy.yogiyo.core.menu.dto.member.MenuDetailsGetResponse;
+import toy.yogiyo.core.menu.repository.MenuQueryRepository;
+import toy.yogiyo.core.menuoption.domain.OptionType;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static toy.yogiyo.document.utils.DocumentLinkGenerator.DocUrl.OPTION_TYPE;
+import static toy.yogiyo.document.utils.DocumentLinkGenerator.generateLinkCode;
+
+@WebMvcTest(MenuController.class)
+@ExtendWith(RestDocumentationExtension.class)
+class MenuControllerTest {
+
+
+    @MockBean
+    MenuQueryRepository menuQueryRepository;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void beforeEach(WebApplicationContext context, RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentationContextProvider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("")
+    void getDetails() throws Exception {
+        // given
+        given(menuQueryRepository.getDetails(anyLong())).willReturn(
+                MenuDetailsGetResponse.builder()
+                        .id(1L)
+                        .name("메뉴 1")
+                        .content("메뉴 1 입니다.")
+                        .picture("/images/hamburger.jpg")
+                        .price(5000)
+                        .reviewNum(20)
+                        .optionGroups(List.of(
+                                MenuDetailsGetResponse.OptionGroupDto.builder()
+                                        .id(1L)
+                                        .name("옵션그룹 1")
+                                        .count(2)
+                                        .optionType(OptionType.REQUIRED)
+                                        .isPossibleCount(false)
+                                        .options(List.of(
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(12493L)
+                                                        .content("옵션 1")
+                                                        .price(2500)
+                                                        .build(),
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(12494L)
+                                                        .content("옵션 2")
+                                                        .price(3000)
+                                                        .build(),
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(12495L)
+                                                        .content("옵션 3")
+                                                        .price(2500)
+                                                        .build()
+                                        ))
+                                        .build(),
+                                MenuDetailsGetResponse.OptionGroupDto.builder()
+                                        .id(2L)
+                                        .name("옵션그룹 2")
+                                        .count(2)
+                                        .optionType(OptionType.OPTIONAL)
+                                        .isPossibleCount(false)
+                                        .options(List.of(
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(12497L)
+                                                        .content("옵션 1")
+                                                        .price(1500)
+                                                        .build(),
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(12498L)
+                                                        .content("옵션 2")
+                                                        .price(2500)
+                                                        .build(),
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(12499L)
+                                                        .content("옵션 3")
+                                                        .price(500)
+                                                        .build(),
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(124500L)
+                                                        .content("옵션 4")
+                                                        .price(2000)
+                                                        .build(),
+                                                MenuDetailsGetResponse.OptionDto.builder()
+                                                        .id(12501L)
+                                                        .content("옵션 5")
+                                                        .price(1000)
+                                                        .build()
+                                        ))
+                                        .build()
+
+                        ))
+                        .build()
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(get("/member/menu/{menuId}", 1));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("member/menu/details",
+                        pathParameters(
+                                parameterWithName("menuId").description("메뉴 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(NUMBER).description("메뉴 ID"),
+                                fieldWithPath("name").type(STRING).description("메뉴 이름"),
+                                fieldWithPath("content").type(STRING).description("메뉴 설명"),
+                                fieldWithPath("picture").type(STRING).description("메뉴 사진"),
+                                fieldWithPath("price").type(NUMBER).description("메뉴 가격"),
+                                fieldWithPath("reviewNum").type(NUMBER).description("메뉴 리뷰 개수"),
+                                fieldWithPath("optionGroups[].id").type(NUMBER).description("옵션 그룹 ID"),
+                                fieldWithPath("optionGroups[].name").type(STRING).description("옵션 그룹 명"),
+                                fieldWithPath("optionGroups[].count").type(NUMBER).description("옵션 선택 가능 개수"),
+                                fieldWithPath("optionGroups[].optionType").type(STRING).description(generateLinkCode(OPTION_TYPE)),
+                                fieldWithPath("optionGroups[].possibleCount").type(BOOLEAN).description("수량 조절 가능 여부"),
+                                fieldWithPath("optionGroups[].options[].id").type(NUMBER).description("옵션 ID"),
+                                fieldWithPath("optionGroups[].options[].content").type(STRING).description("옵션 내용"),
+                                fieldWithPath("optionGroups[].options[].price").type(NUMBER).description("옵션 가격")
+                        )
+                ));
+    }
+
+
+}

--- a/src/test/java/toy/yogiyo/api/member/MenuGroupControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/MenuGroupControllerTest.java
@@ -1,0 +1,116 @@
+package toy.yogiyo.api.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import toy.yogiyo.core.menu.domain.Menu;
+import toy.yogiyo.core.menu.domain.MenuGroup;
+import toy.yogiyo.core.menu.repository.MenuGroupRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MenuGroupController.class)
+@ExtendWith(RestDocumentationExtension.class)
+class MenuGroupControllerTest {
+
+    @MockBean
+    MenuGroupRepository menuGroupRepository;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void beforeEach(WebApplicationContext context, RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentationContextProvider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+
+        objectMapper = new ObjectMapper();
+    }
+    @Test
+    @DisplayName("메뉴 그룹 전체 조회")
+    void getMenuGroups() throws Exception {
+        // given
+        List<Menu> menus1 = Arrays.asList(
+                Menu.builder().id(1L).name("메뉴 1").content("메뉴 1 설명").picture("image.png").price(10000).reviewNum(20).position(1).build(),
+                Menu.builder().id(2L).name("메뉴 2").content("메뉴 2 설명").picture("image.png").price(10000).reviewNum(0).position(2).build(),
+                Menu.builder().id(3L).name("메뉴 3").content("메뉴 3 설명").picture("image.png").price(10000).reviewNum(100).position(3).build()
+        );
+        List<Menu> menus2 = Arrays.asList(
+                Menu.builder().id(4L).name("메뉴 4").content("메뉴 4 설명").picture("image.png").price(10000).reviewNum(5).position(1).build(),
+                Menu.builder().id(5L).name("메뉴 5").content("메뉴 5 설명").picture("image.png").price(10000).reviewNum(10).position(2).build(),
+                Menu.builder().id(6L).name("메뉴 6").content("메뉴 6 설명").picture("image.png").price(10000).reviewNum(3).position(3).build()
+        );
+
+        List<MenuGroup> menuGroups = Arrays.asList(
+                MenuGroup.builder().id(1L).name("메뉴 그룹1").content("메뉴 그룹1 설명").menus(menus1).build(),
+                MenuGroup.builder().id(2L).name("메뉴 그룹2").content("메뉴 그룹2 설명").menus(menus2).build()
+        );
+        given(menuGroupRepository.findAllWithMenuByShopId(anyLong())).willReturn(menuGroups);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/member/menu-group/shop/{shopId}", 1));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.menuGroups").isArray())
+                .andExpect(jsonPath("$.menuGroups.length()").value(2))
+                .andExpect(jsonPath("$.menuGroups[0].id").value(1))
+                .andExpect(jsonPath("$.menuGroups[1].id").value(2))
+                .andExpect(jsonPath("$.menuGroups[0].menus[0].id").value(1))
+                .andExpect(jsonPath("$.menuGroups[0].menus[1].id").value(2))
+                .andExpect(jsonPath("$.menuGroups[0].menus[2].id").value(3))
+                .andDo(print())
+                .andDo(document("member/menu-group/find-all",
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("menuGroups").type(JsonFieldType.ARRAY).description("메뉴 그룹 Array"),
+                                fieldWithPath("menuGroups[].id").type(JsonFieldType.NUMBER).description("메뉴 그룹 ID"),
+                                fieldWithPath("menuGroups[].name").type(JsonFieldType.STRING).description("메뉴 그룹 이름"),
+                                fieldWithPath("menuGroups[].content").type(JsonFieldType.STRING).description("메뉴 그룹 설명"),
+                                fieldWithPath("menuGroups[].menus").type(JsonFieldType.ARRAY).description("메뉴 Array"),
+                                fieldWithPath("menuGroups[].menus[].id").type(JsonFieldType.NUMBER).description("메뉴 ID"),
+                                fieldWithPath("menuGroups[].menus[].name").type(JsonFieldType.STRING).description("메뉴 이름"),
+                                fieldWithPath("menuGroups[].menus[].content").type(JsonFieldType.STRING).description("메뉴 설명"),
+                                fieldWithPath("menuGroups[].menus[].price").type(JsonFieldType.NUMBER).description("메뉴 가격"),
+                                fieldWithPath("menuGroups[].menus[].reviewNum").type(JsonFieldType.NUMBER).description("리뷰 개수"),
+                                fieldWithPath("menuGroups[].menus[].picture").type(JsonFieldType.STRING).description("메뉴 사진")
+                        )
+                ));
+    }
+
+}

--- a/src/test/java/toy/yogiyo/api/member/OrderControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/OrderControllerTest.java
@@ -105,7 +105,7 @@ class OrderControllerTest {
         doNothing().when(orderService).createOrder(any(), any());
 
         mockMvc.perform(
-                    post("/order/create")
+                    post("/member/order/create")
                     .contentType(MediaType.APPLICATION_JSON)
                     .header("Authorization", jwt)
                     .content(objectMapper.writeValueAsString(orderCreateRequest))
@@ -179,7 +179,7 @@ class OrderControllerTest {
         given(orderService.getOrderHistory(any(), any())).willReturn(orderHistoryResponse);
 
         mockMvc.perform(
-                    get("/order/scroll")
+                    get("/member/order/scroll")
                     .contentType(MediaType.APPLICATION_JSON)
                     .header("Authorization", jwt)
                     .param("lastId", "1")
@@ -262,7 +262,7 @@ class OrderControllerTest {
         given(orderService.getOrderDetail(any(), any())).willReturn(orderDetailResponse);
 
         mockMvc.perform(
-                    get("/order/details")
+                    get("/member/order/details")
                     .contentType(MediaType.APPLICATION_JSON)
                     .header("Authorization", jwt)
                     .param("orderId", "1")

--- a/src/test/java/toy/yogiyo/api/member/ReviewControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/ReviewControllerTest.java
@@ -83,7 +83,7 @@ class ReviewControllerTest {
         doNothing().when(reviewService).create(any(), any());
 
         mockMvc.perform(
-                    post("/review/write")
+                    post("/member/review/write")
                     .contentType(MediaType.APPLICATION_JSON)
                     .header("Authorization", jwt)
                     .content(objectMapper.writeValueAsString(reviewCreateRequest))
@@ -146,7 +146,7 @@ class ReviewControllerTest {
         given(reviewService.getMemberReviews(any(), any())).willReturn(memberReviewScrollResponse);
 
         mockMvc.perform(
-                get("/review/memberReview")
+                get("/member/review/memberReview")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", jwt)
                         .param("lastId", "6")

--- a/src/test/java/toy/yogiyo/api/member/ShopControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/ShopControllerTest.java
@@ -9,38 +9,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import toy.yogiyo.api.member.ShopController;
-import toy.yogiyo.common.security.WithLoginOwner;
-import toy.yogiyo.core.category.domain.Category;
-import toy.yogiyo.core.category.domain.CategoryShop;
-import toy.yogiyo.core.shop.domain.*;
-import toy.yogiyo.core.shop.dto.*;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollResponse;
 import toy.yogiyo.core.shop.service.ShopService;
-import toy.yogiyo.util.ConstrainedFields;
 
-import java.io.IOException;
 import java.math.BigDecimal;
-import java.time.LocalTime;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -51,8 +36,6 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static toy.yogiyo.document.utils.DocumentLinkGenerator.DocUrl.DAYS;
-import static toy.yogiyo.document.utils.DocumentLinkGenerator.generateLinkCode;
 
 @WebMvcTest(ShopController.class)
 @ExtendWith(RestDocumentationExtension.class)
@@ -66,8 +49,6 @@ class ShopControllerTest {
 
     ObjectMapper objectMapper;
 
-    final String jwt = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIsInByb3ZpZGVyVHlwZSI6IkRFRkFVTFQiLCJleHAiOjE2OTQ5NjY4Mjh9.Ls1wnxU41I99ijXRyKfkYI2w3kd-Q_qA2QgCLgpDTKk";
-
     @BeforeEach
     void beforeEach(WebApplicationContext context, RestDocumentationContextProvider restDocumentationContextProvider) {
         mockMvc = MockMvcBuilders.webAppContextSetup(context)
@@ -78,402 +59,6 @@ class ShopControllerTest {
                 .build();
 
         objectMapper = new ObjectMapper();
-    }
-
-    @Test
-    @DisplayName("가게 입점")
-    @WithLoginOwner
-    void register() throws Exception {
-        // given
-        ShopRegisterRequest registerRequest = ShopRegisterRequest.builder()
-                .name("롯데리아")
-                .callNumber("010-1234-5678")
-                .address("서울 강남구 영동대로 513")
-                .latitude(36.674648)
-                .longitude(127.448544)
-                .categories(Arrays.asList("치킨", "한식", "중국집"))
-                .build();
-
-        MockMultipartFile requestJson = new MockMultipartFile(
-                "shopData",
-                "jsonData",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsString(registerRequest).getBytes());
-        MockMultipartFile icon = givenIcon();
-        MockMultipartFile banner = givenBanner();
-        when(shopService.register(any(), any(), any(), any())).thenReturn(1L);
-
-        // when
-        ResultActions result = mockMvc.perform(multipart("/shop/register")
-                .file(icon)
-                .file(banner)
-                .file(requestJson)
-                .header(HttpHeaders.AUTHORIZATION, jwt)
-                .contentType(MediaType.MULTIPART_FORM_DATA));
-
-        // then
-        ConstrainedFields fields = new ConstrainedFields(ShopRegisterRequest.class);
-        result.andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1))
-                .andDo(print())
-                .andDo(document("shop/register",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
-                        ),
-                        requestParts(
-                                partWithName("icon").description("아이콘"),
-                                partWithName("banner").description("배너 이미지"),
-                                partWithName("shopData").description("가게 정보")
-                        ),
-                        requestPartFields("shopData",
-                                fields.withPath("name").type(JsonFieldType.STRING).description("가게명"),
-                                fields.withPath("callNumber").type(JsonFieldType.STRING).description("전화번호"),
-                                fields.withPath("address").type(JsonFieldType.STRING).description("주소"),
-                                fields.withPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
-                                fields.withPath("longitude").type(JsonFieldType.NUMBER).description("경도"),
-                                fields.withPath("categories").type(JsonFieldType.ARRAY).description("카테고리 Array")
-                        ),
-                        responseFields(
-                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 ID")
-                        )
-                ));
-    }
-
-
-    @Test
-    @DisplayName("가게 정보 조회")
-    void getInfo() throws Exception {
-        // given
-        ShopInfoResponse response = ShopInfoResponse.from(givenShop());
-        when(shopService.getInfo(anyLong())).thenReturn(response);
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/shop/{shopId}/info", 1L));
-
-        // then
-        result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(response.getId()))
-                .andExpect(jsonPath("$.name").value(response.getName()))
-                .andExpect(jsonPath("$.callNumber").value(response.getCallNumber()))
-                .andExpect(jsonPath("$.address").value(response.getAddress()))
-                .andExpect(jsonPath("$.categories").isArray())
-                .andExpect(jsonPath("$.categories.length()").value(response.getCategories().size()))
-                .andDo(print())
-                .andDo(document("shop/get-info",
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 ID"),
-                                fieldWithPath("name").type(JsonFieldType.STRING).description("가게명"),
-                                fieldWithPath("callNumber").type(JsonFieldType.STRING).description("전화번호"),
-                                fieldWithPath("address").type(JsonFieldType.STRING).description("주소"),
-                                fieldWithPath("categories").type(JsonFieldType.ARRAY).description("카테고리명 리스트")
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("사장님 공지 조회")
-    void getNotice() throws Exception {
-        // given
-        ShopNoticeResponse response = ShopNoticeResponse.builder()
-                .title("공지 제목")
-                .notice("공지 내용")
-                .images(List.of("/images/image1.png", "/images/image2.png"))
-                .build();
-        when(shopService.getNotice(anyLong())).thenReturn(response);
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/shop/{shopId}/notice", 1));
-
-        // then
-        result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.title").value("공지 제목"))
-                .andExpect(jsonPath("$.notice").value("공지 내용"))
-                .andExpect(jsonPath("$.images[0]").value("/images/image1.png"))
-                .andExpect(jsonPath("$.images[1]").value("/images/image2.png"))
-                .andDo(print())
-                .andDo(document("shop/get-notice",
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("title").type(JsonFieldType.STRING).description("사장님 공지 제목"),
-                                fieldWithPath("notice").type(JsonFieldType.STRING).description("사장님 공지 내용"),
-                                fieldWithPath("images").type(JsonFieldType.ARRAY).description("사장님 공지 사진 리스트")
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("영업 시간 조회")
-    void getBusinessHours() throws Exception {
-        // given
-        ShopBusinessHourResponse response = ShopBusinessHourResponse.builder()
-                .businessHours(List.of(
-                        new ShopBusinessHourResponse.BusinessHoursDto(BusinessHours.builder()
-                                .dayOfWeek(Days.EVERYDAY)
-                                .isOpen(true)
-                                .openTime(LocalTime.of(10, 0))
-                                .closeTime(LocalTime.of(20, 0))
-                                .build()
-                        )
-                ))
-                .build();
-        when(shopService.getBusinessHours(anyLong())).thenReturn(response);
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/shop/{shopId}/business-hours", 1));
-
-        // then
-        result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.businessHours.length()").value(1))
-                .andExpect(jsonPath("$.businessHours[0].dayOfWeek").value("EVERYDAY"))
-                .andExpect(jsonPath("$.businessHours[0].openTime").value("10:00:00"))
-                .andDo(print())
-                .andDo(document("shop/get-business-hours",
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("businessHours").type(JsonFieldType.ARRAY).description("영업 시간"),
-                                fieldWithPath("businessHours[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS)),
-                                fieldWithPath("businessHours[].isOpen").type(JsonFieldType.BOOLEAN).description("영업일"),
-                                fieldWithPath("businessHours[].openTime").type(JsonFieldType.STRING).description("오픈 시간"),
-                                fieldWithPath("businessHours[].closeTime").type(JsonFieldType.STRING).description("마감 시간"),
-                                fieldWithPath("businessHours[].breakTimeStart").type(JsonFieldType.STRING).description("휴게 시간 (시작)").optional(),
-                                fieldWithPath("businessHours[].breakTimeEnd").type(JsonFieldType.STRING).description("휴게 시간 (종료)").optional()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("휴무일 조회")
-    void getCloseDays() throws Exception {
-        // given
-        when(shopService.getCloseDays(anyLong())).thenReturn(ShopCloseDayResponse.builder()
-                .closeDays(List.of(
-                        new ShopCloseDayResponse.CloseDayDto(CloseDay.builder().weekNumOfMonth(1).dayOfWeek(Days.MONDAY).build()),
-                        new ShopCloseDayResponse.CloseDayDto(CloseDay.builder().weekNumOfMonth(3).dayOfWeek(Days.MONDAY).build())
-                ))
-                .build());
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/shop/{shopId}/close-day", 1));
-
-        // then
-        result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.closeDays[0].weekNumOfMonth").value(1))
-                .andExpect(jsonPath("$.closeDays[0].dayOfWeek").value("MONDAY"))
-                .andExpect(jsonPath("$.closeDays[1].weekNumOfMonth").value(3))
-                .andExpect(jsonPath("$.closeDays[1].dayOfWeek").value("MONDAY"))
-                .andDo(print())
-                .andDo(document("shop/get-close-day",
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("closeDays").type(JsonFieldType.ARRAY).description("휴무일 리스트"),
-                                fieldWithPath("closeDays[].weekNumOfMonth").type(JsonFieldType.NUMBER).description("(1~4)번째 주"),
-                                fieldWithPath("closeDays[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS))
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("가게 전화번호 수정")
-    @WithLoginOwner
-    void updateCallNumber() throws Exception {
-        // given
-        ShopUpdateCallNumberRequest updateRequest = ShopUpdateCallNumberRequest.builder()
-                .callNumber("010-1234-5678")
-                .build();
-
-        doNothing().when(shopService).updateCallNumber(anyLong(), any(), any());
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/shop/{shopId}/call-number/update", 1L)
-                .header(HttpHeaders.AUTHORIZATION, jwt)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .content(objectMapper.writeValueAsString(updateRequest)));
-
-        // then
-        ConstrainedFields fields = new ConstrainedFields(ShopUpdateCallNumberRequest.class);
-        result.andExpect(status().isNoContent())
-                .andDo(print())
-                .andDo(document("shop/update-call-number",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
-                        ),
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        requestFields(
-                                fields.withPath("callNumber").type(JsonFieldType.STRING).description("전화번호")
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("사장님 공지 수정")
-    @WithLoginOwner
-    void updateNotice() throws Exception {
-        // given
-        doNothing().when(shopService).updateNotice(anyLong(), any(), any(), anyList());
-        ShopNoticeUpdateRequest request = ShopNoticeUpdateRequest.builder()
-                .title("공지 제목")
-                .notice("사장님 공지")
-                .build();
-        MockMultipartFile image1 = new MockMultipartFile("images", "image1.png", MediaType.IMAGE_PNG_VALUE, "<<image.png>>".getBytes());
-        MockMultipartFile image2 = new MockMultipartFile("images", "image2.png", MediaType.IMAGE_PNG_VALUE, "<<image.png>>".getBytes());
-        MockMultipartFile image3 = new MockMultipartFile("images", "image3.png", MediaType.IMAGE_PNG_VALUE, "<<image.png>>".getBytes());
-        MockMultipartFile requestJson = new MockMultipartFile(
-                "noticeData",
-                "jsonData",
-                MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsString(request).getBytes());
-
-
-        // when
-        ConstrainedFields fields = new ConstrainedFields(ShopNoticeUpdateRequest.class);
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.multipart("/shop/{shopId}/notice/update", 1)
-                        .file(image1)
-                        .file(image2)
-                        .file(image3)
-                        .file(requestJson)
-                .header(HttpHeaders.AUTHORIZATION, jwt)
-                .contentType(MediaType.MULTIPART_FORM_DATA));
-
-        // then
-        result.andExpect(status().isNoContent())
-                .andDo(print())
-                .andDo(document("shop/update-notice",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
-                        ),
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        requestParts(
-                                partWithName("images").description("첨부 사진"),
-                                partWithName("noticeData").description("공지 Json")
-                        ),
-                        requestPartFields("noticeData",
-                                fields.withPath("title").type(JsonFieldType.STRING).description("공지 제목"),
-                                fields.withPath("notice").type(JsonFieldType.STRING).description("공지 내용")
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("영업 시간 수정")
-    @WithLoginOwner
-    void updateBusinessHours() throws Exception {
-        // given
-        doNothing().when(shopService).updateBusinessHours(anyLong(), any(), any());
-        ShopBusinessHourUpdateRequest request = ShopBusinessHourUpdateRequest.builder()
-                .businessHours(List.of(
-                        new ShopBusinessHourUpdateRequest.BusinessHoursDto(
-                                Days.EVERYDAY,
-                                true,
-                                LocalTime.of(10, 0),
-                                LocalTime.of(20, 0),
-                                null,
-                                null)
-                ))
-                .build();
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/shop/{shopId}/business-hours/update", 1)
-                .header(HttpHeaders.AUTHORIZATION, jwt)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request))
-                .characterEncoding("utf8"));
-
-        // then
-        ConstrainedFields fields = new ConstrainedFields(ShopBusinessHourUpdateRequest.class);
-        result.andExpect(status().isNoContent())
-                .andDo(print())
-                .andDo(document("shop/update-business-hours",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
-                        ),
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        requestFields(
-                                fields.withPath("businessHours").type(JsonFieldType.ARRAY).description("영업 시간"),
-                                fields.withPath("businessHours[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS)),
-                                fields.withPath("businessHours[].isOpen").type(JsonFieldType.BOOLEAN).description("영업일"),
-                                fields.withPath("businessHours[].openTime").type(JsonFieldType.STRING).description("오픈 시간"),
-                                fields.withPath("businessHours[].closeTime").type(JsonFieldType.STRING).description("마감 시간"),
-                                fields.withPath("businessHours[].breakTimeStart").type(JsonFieldType.STRING).description("휴게 시간 (시작)").optional(),
-                                fields.withPath("businessHours[].breakTimeEnd").type(JsonFieldType.STRING).description("휴게 시간 (종료)").optional()
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("휴무일 수정")
-    void updateCloseDays() throws Exception {
-        // given
-        doNothing().when(shopService).updateCloseDays(anyLong(), any(), any());
-        ShopCloseDayUpdateRequest request = ShopCloseDayUpdateRequest.builder()
-                .closeDays(List.of(
-                        new ShopCloseDayUpdateRequest.CloseDayDto(1, Days.MONDAY),
-                        new ShopCloseDayUpdateRequest.CloseDayDto(3, Days.MONDAY)
-                ))
-                .build();
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/shop/{shopId}/close-day/update", 1)
-                .header(HttpHeaders.AUTHORIZATION, jwt)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)));
-
-        // then
-        ConstrainedFields fields = new ConstrainedFields(ShopCloseDayUpdateRequest.class);
-        result.andExpect(status().isNoContent())
-                .andDo(print())
-                .andDo(document("shop/update-close-day",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
-                        ),
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        ),
-                        requestFields(
-                                fields.withPath("closeDays").type(JsonFieldType.ARRAY).description("휴무일 리스트"),
-                                fields.withPath("closeDays[].weekNumOfMonth").type(JsonFieldType.NUMBER).description("(1~4)번째 주"),
-                                fields.withPath("closeDays[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS))
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("가게 삭제")
-    @WithLoginOwner
-    void deleteShop() throws Exception {
-        // given
-        doNothing().when(shopService).delete(anyLong(), any());
-
-        // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/shop/{shopId}/delete", 1L)
-                .header(HttpHeaders.AUTHORIZATION, jwt));
-
-        // then
-        verify(shopService).delete(anyLong(), any());
-        result.andExpect(status().isNoContent())
-                .andDo(print())
-                .andDo(document("shop/delete",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
-                        ),
-                        pathParameters(
-                                parameterWithName("shopId").description("가게 ID")
-                        )
-                ));
     }
 
     @DisplayName("상점 리스트 조회")
@@ -526,7 +111,7 @@ class ShopControllerTest {
 
         given(shopService.getList(any())).willReturn(response);
 
-        mockMvc.perform(get("/shop/list")
+        mockMvc.perform(get("/member/shop/list")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("category", "치킨")
                         .param("sortOption","ORDER")
@@ -578,34 +163,6 @@ class ShopControllerTest {
 
 
         verify(shopService).getList(any());
-    }
-
-    private Shop givenShop() {
-        Shop shop = Shop.builder()
-                .id(1L)
-                .name("롯데리아")
-                .icon("692c0741-f234-448e-ba3f-35b5a394f33d.png")
-                .banner("692c0741-f234-448e-ba3f-35b5a394f33d.png")
-                .ownerNotice("사장님 공지")
-                .callNumber("010-1234-5678")
-                .address("서울 강남구 영동대로 513")
-                .categoryShop(Arrays.asList(
-                        CategoryShop.builder().category(Category.builder().name("카테고리1").build()).build(),
-                        CategoryShop.builder().category(Category.builder().name("카테고리2").build()).build(),
-                        CategoryShop.builder().category(Category.builder().name("카테고리3").build()).build(),
-                        CategoryShop.builder().category(Category.builder().name("카테고리4").build()).build()
-                ))
-                .build();
-
-        return shop;
-    }
-
-    private MockMultipartFile givenIcon() throws IOException {
-        return new MockMultipartFile("icon", "images.png", MediaType.IMAGE_PNG_VALUE, "<<image png>>".getBytes());
-    }
-
-    private MockMultipartFile givenBanner() throws IOException {
-        return new MockMultipartFile("banner", "images.png", MediaType.IMAGE_PNG_VALUE, "<<image png>>".getBytes());
     }
 
 }

--- a/src/test/java/toy/yogiyo/api/member/ShopControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/ShopControllerTest.java
@@ -185,6 +185,7 @@ class ShopControllerTest {
                         .likeNum(314L)
                         .totalScore(BigDecimal.valueOf(3.34))
                         .banner("/images/banner.jpg")
+                        .noticeTitle("공지 사항")
                         .distance(7029.0)
                         .minOrderPrice(10000)
                         .minDeliveryPrice(3000)
@@ -221,6 +222,7 @@ class ShopControllerTest {
                                 fieldWithPath("likeNum").type(JsonFieldType.NUMBER).description("찜 개수"),
                                 fieldWithPath("totalScore").type(JsonFieldType.NUMBER).description("별점"),
                                 fieldWithPath("banner").type(JsonFieldType.STRING).description("가게 배너 이미지"),
+                                fieldWithPath("noticeTitle").type(JsonFieldType.STRING).description("공지 사항 제목"),
                                 fieldWithPath("distance").type(JsonFieldType.NUMBER).description("거리"),
                                 fieldWithPath("minOrderPrice").type(JsonFieldType.NUMBER).description("최소 주문 금액"),
                                 fieldWithPath("minDeliveryPrice").type(JsonFieldType.NUMBER).description("최소 배달 금액"),

--- a/src/test/java/toy/yogiyo/api/member/ShopControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/ShopControllerTest.java
@@ -12,20 +12,25 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import toy.yogiyo.common.security.WithLoginMember;
+import toy.yogiyo.core.shop.domain.Days;
 import toy.yogiyo.core.shop.dto.ShopDetailsResponse;
+import toy.yogiyo.core.shop.dto.member.ShopInfoResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListRequest;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollListResponse;
 import toy.yogiyo.core.shop.dto.scroll.ShopScrollResponse;
 import toy.yogiyo.core.shop.repository.ShopRepository;
 import toy.yogiyo.core.shop.service.ShopService;
+import toy.yogiyo.document.utils.DocumentLinkGenerator;
 
 import java.math.BigDecimal;
+import java.time.LocalTime;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
@@ -40,6 +45,8 @@ import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static toy.yogiyo.document.utils.DocumentLinkGenerator.DocUrl.*;
+import static toy.yogiyo.document.utils.DocumentLinkGenerator.generateLinkCode;
 
 @WebMvcTest(ShopController.class)
 @ExtendWith(RestDocumentationExtension.class)
@@ -228,6 +235,140 @@ class ShopControllerTest {
                                 fieldWithPath("minDeliveryPrice").type(JsonFieldType.NUMBER).description("최소 배달 금액"),
                                 fieldWithPath("isLike").type(JsonFieldType.BOOLEAN).description("찜 여부")
                         )
+                ));
+    }
+
+    @Test
+    @DisplayName("가게 원산지 정보 조회")
+    void info() throws Exception {
+        // given
+        given(shopRepository.info(anyLong(), anyString())).willReturn(
+                ShopInfoResponse.builder()
+                        .id(1L)
+                        .name("음식점 1")
+                        .noticeTitle("공지사항")
+                        .ownerNotice("공지사항 입니다.")
+                        .noticeImages(List.of("/images/image1.png", "/images/image2.png"))
+                        .callNumber("010-1234-5678")
+                        .address("서울특별시 송파구 올림픽로 300")
+                        .deliveryPriceInfos(List.of(
+                                ShopInfoResponse.DeliveryPriceInfoDto.builder()
+                                        .id(4L)
+                                        .deliveryPrice(5000)
+                                        .orderPrice(26000)
+                                        .build(),
+                                ShopInfoResponse.DeliveryPriceInfoDto.builder()
+                                        .id(5L)
+                                        .deliveryPrice(4000)
+                                        .orderPrice(31000)
+                                        .build(),
+                                ShopInfoResponse.DeliveryPriceInfoDto.builder()
+                                        .id(6L)
+                                        .deliveryPrice(2000)
+                                        .orderPrice(15000)
+                                        .build()
+                        ))
+                        .businessHours(List.of(
+                                ShopInfoResponse.BusinessHoursDto.builder()
+                                        .id(1L)
+                                        .breakTimeStart(null)
+                                        .breakTimeEnd(null)
+                                        .openTime(LocalTime.of(8, 0))
+                                        .closeTime(LocalTime.of(18, 0))
+                                        .dayOfWeek(Days.SUNDAY)
+                                        .isOpen(true)
+                                        .build(),
+                                ShopInfoResponse.BusinessHoursDto.builder()
+                                        .id(2L)
+                                        .breakTimeStart(LocalTime.of(14, 0))
+                                        .breakTimeEnd(LocalTime.of(16, 0))
+                                        .openTime(LocalTime.of(8, 0))
+                                        .closeTime(LocalTime.of(19, 0))
+                                        .dayOfWeek(Days.MONDAY)
+                                        .isOpen(false)
+                                        .build(),
+                                ShopInfoResponse.BusinessHoursDto.builder()
+                                        .id(3L)
+                                        .breakTimeStart(LocalTime.of(14, 0))
+                                        .breakTimeEnd(LocalTime.of(16, 0))
+                                        .openTime(LocalTime.of(8, 0))
+                                        .closeTime(LocalTime.of(19, 0))
+                                        .dayOfWeek(Days.TUESDAY)
+                                        .isOpen(true)
+                                        .build(),
+                                ShopInfoResponse.BusinessHoursDto.builder()
+                                        .id(4L)
+                                        .breakTimeStart(null)
+                                        .breakTimeEnd(null)
+                                        .openTime(LocalTime.of(7, 0))
+                                        .closeTime(LocalTime.of(19, 0))
+                                        .dayOfWeek(Days.WEDNESDAY)
+                                        .isOpen(true)
+                                        .build(),
+                                ShopInfoResponse.BusinessHoursDto.builder()
+                                        .id(5L)
+                                        .breakTimeStart(LocalTime.of(14, 0))
+                                        .breakTimeEnd(LocalTime.of(16, 0))
+                                        .openTime(LocalTime.of(8, 0))
+                                        .closeTime(LocalTime.of(0, 0))
+                                        .dayOfWeek(Days.THURSDAY)
+                                        .isOpen(false)
+                                        .build(),
+                                ShopInfoResponse.BusinessHoursDto.builder()
+                                        .id(6L)
+                                        .breakTimeStart(null)
+                                        .breakTimeEnd(null)
+                                        .openTime(LocalTime.of(8, 0))
+                                        .closeTime(LocalTime.of(22, 0))
+                                        .dayOfWeek(Days.FRIDAY)
+                                        .isOpen(false)
+                                        .build(),
+                                ShopInfoResponse.BusinessHoursDto.builder()
+                                        .id(7L)
+                                        .breakTimeStart(LocalTime.of(14, 0))
+                                        .breakTimeEnd(LocalTime.of(16, 0))
+                                        .openTime(LocalTime.of(7, 0))
+                                        .closeTime(LocalTime.of(19, 0))
+                                        .dayOfWeek(Days.SATURDAY)
+                                        .isOpen(true)
+                                        .build()
+                        ))
+                        .build()
+        );
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/member/shop/{shopId}/info", 1)
+                .param("code", "4783025326"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("member/shop/info",
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        requestParameters(
+                                parameterWithName("code").description("법정동 코드")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 ID"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("가게명"),
+                                fieldWithPath("noticeTitle").type(JsonFieldType.STRING).description("공지 사항 제목"),
+                                fieldWithPath("ownerNotice").type(JsonFieldType.STRING).description("공지 사항 내용"),
+                                fieldWithPath("noticeImages[]").type(JsonFieldType.ARRAY).description("공지 사항 이미지 리스트"),
+                                fieldWithPath("callNumber").type(JsonFieldType.STRING).description("가게 전화 번호"),
+                                fieldWithPath("address").type(JsonFieldType.STRING).description("가게 주소"),
+                                fieldWithPath("deliveryPriceInfos[].id").type(JsonFieldType.NUMBER).description("배달 요금 ID"),
+                                fieldWithPath("deliveryPriceInfos[].deliveryPrice").type(JsonFieldType.NUMBER).description("배달 요금"),
+                                fieldWithPath("deliveryPriceInfos[].orderPrice").type(JsonFieldType.NUMBER).description("주문 금액"),
+                                fieldWithPath("businessHours[].id").type(JsonFieldType.NUMBER).description("영업 시간 ID"),
+                                fieldWithPath("businessHours[].breakTimeStart").type(JsonFieldType.STRING).description("휴게 시간 시작").optional(),
+                                fieldWithPath("businessHours[].breakTimeEnd").type(JsonFieldType.STRING).description("휴게 시간 끝").optional(),
+                                fieldWithPath("businessHours[].openTime").type(JsonFieldType.STRING).description("영업 시작 시간"),
+                                fieldWithPath("businessHours[].closeTime").type(JsonFieldType.STRING).description("영업 종료 시간"),
+                                fieldWithPath("businessHours[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS)),
+                                fieldWithPath("businessHours[].open").type(JsonFieldType.BOOLEAN).description("영업 유무")
+                                )
                 ));
     }
 

--- a/src/test/java/toy/yogiyo/api/member/SignatureMenuControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/member/SignatureMenuControllerTest.java
@@ -1,0 +1,105 @@
+package toy.yogiyo.api.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import toy.yogiyo.core.menu.domain.Menu;
+import toy.yogiyo.core.menu.domain.SignatureMenu;
+import toy.yogiyo.core.menu.service.SignatureMenuService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SignatureMenuController.class)
+@ExtendWith(RestDocumentationExtension.class)
+class SignatureMenuControllerTest {
+
+    @MockBean
+    SignatureMenuService signatureMenuService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    ObjectMapper objectMapper;
+
+
+    @BeforeEach
+    void beforeEach(WebApplicationContext context, RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentationContextProvider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("대표 메뉴 전체 조회")
+    void getSignatureMenus() throws Exception {
+        // given
+        List<SignatureMenu> signatureMenus = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            signatureMenus.add(SignatureMenu.builder().id(i + 1L).position(i + 1)
+                    .menu(Menu.builder().id(i + 1L).name("메뉴" + i).content("메뉴" + i + " 설명").picture("image.png").price(10000).build())
+                    .build());
+        }
+        given(signatureMenuService.getAll(anyLong())).willReturn(signatureMenus);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/member/signature-menu/shop/{shopId}", 1));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.signatureMenus").isArray())
+                .andExpect(jsonPath("$.signatureMenus.length()").value(5))
+                .andExpect(jsonPath("$.signatureMenus[0].id").value(1))
+                .andExpect(jsonPath("$.signatureMenus[1].id").value(2))
+                .andExpect(jsonPath("$.signatureMenus[2].id").value(3))
+                .andExpect(jsonPath("$.signatureMenus[3].id").value(4))
+                .andExpect(jsonPath("$.signatureMenus[4].id").value(5))
+                .andDo(print())
+                .andDo(document("member/signature-menu/find-all",
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("signatureMenus").type(JsonFieldType.ARRAY).description("대표 메뉴 Array"),
+                                fieldWithPath("signatureMenus[].id").type(JsonFieldType.NUMBER).description("메뉴 ID"),
+                                fieldWithPath("signatureMenus[].name").type(JsonFieldType.STRING).description("메뉴 이름"),
+                                fieldWithPath("signatureMenus[].content").type(JsonFieldType.STRING).description("메뉴 설명"),
+                                fieldWithPath("signatureMenus[].picture").type(JsonFieldType.STRING).description("메뉴 사진"),
+                                fieldWithPath("signatureMenus[].price").type(JsonFieldType.NUMBER).description("메뉴 가격")
+                        )
+                ));
+    }
+
+}

--- a/src/test/java/toy/yogiyo/api/owner/DeliveryPlaceControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/owner/DeliveryPlaceControllerTest.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import toy.yogiyo.api.owner.DeliveryPlaceController;
 import toy.yogiyo.common.security.WithLoginOwner;
 import toy.yogiyo.core.deliveryplace.domain.DeliveryPlace;
 import toy.yogiyo.core.deliveryplace.domain.DeliveryPriceInfo;
@@ -29,7 +28,6 @@ import toy.yogiyo.util.ConstrainedFields;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;

--- a/src/test/java/toy/yogiyo/api/owner/MenuGroupControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/owner/MenuGroupControllerTest.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +20,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import toy.yogiyo.api.member.MenuGroupController;
 import toy.yogiyo.common.file.ImageFileHandler;
 import toy.yogiyo.common.file.ImageFileUtil;
 import toy.yogiyo.core.menu.domain.Menu;
@@ -96,7 +95,7 @@ class MenuGroupControllerTest {
             given(menuGroupService.create(any())).willReturn(1L);
 
             // when
-            ResultActions result = mockMvc.perform(post("/menu-group/add")
+            ResultActions result = mockMvc.perform(post("/owner/menu-group/add")
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -143,7 +142,7 @@ class MenuGroupControllerTest {
             given(menuGroupService.getMenuGroups(anyLong())).willReturn(menuGroups);
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/menu-group/shop/{shopId}", 1));
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/menu-group/shop/{shopId}", 1));
 
             // then
             result.andExpect(status().isOk())
@@ -183,7 +182,7 @@ class MenuGroupControllerTest {
             given(menuGroupService.get(anyLong())).willReturn(menuGroup);
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/menu-group/{menuGroupId}", 1));
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/menu-group/{menuGroupId}", 1));
 
             // then
             result.andExpect(status().isOk())
@@ -213,7 +212,7 @@ class MenuGroupControllerTest {
             doNothing().when(menuGroupService).update(any());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/menu-group/{menuGroupId}", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/menu-group/{menuGroupId}", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(updateRequest)));
@@ -248,7 +247,7 @@ class MenuGroupControllerTest {
             doNothing().when(menuGroupService).updateMenuPosition(anyLong(), anyList());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/menu-group/shop/{shopId}/change-position", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/owner/menu-group/shop/{shopId}/change-position", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -278,7 +277,7 @@ class MenuGroupControllerTest {
             doNothing().when(menuGroupService).delete(any());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/menu-group/{menuGroupId}", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/menu-group/{menuGroupId}", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt));
 
             // then
@@ -314,7 +313,7 @@ class MenuGroupControllerTest {
             MockMultipartFile menuData = new MockMultipartFile("menuData", "menuData.json", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(request));
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.multipart("/menu-group/{menuGroupId}/add-menu", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.multipart("/owner/menu-group/{menuGroupId}/add-menu", 1)
                             .file(picture)
                             .file(menuData)
                             .header(HttpHeaders.AUTHORIZATION, jwt));
@@ -359,7 +358,7 @@ class MenuGroupControllerTest {
             given(menuService.getMenus(anyLong())).willReturn(menus);
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/menu-group/{menuGroupId}/menu", 1));
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/menu-group/{menuGroupId}/menu", 1));
 
             // then
             result.andExpect(status().isOk())
@@ -399,7 +398,7 @@ class MenuGroupControllerTest {
             MockMultipartFile menuData = new MockMultipartFile("menuData", "menuData.json", MediaType.APPLICATION_JSON_VALUE, objectMapper.writeValueAsBytes(request));
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.multipart("/menu-group/update-menu/{menuId}", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.multipart("/owner/menu-group/update-menu/{menuId}", 1)
                     .file(picture)
                     .file(menuData)
                     .header(HttpHeaders.AUTHORIZATION, jwt));
@@ -434,7 +433,7 @@ class MenuGroupControllerTest {
             doNothing().when(menuService).delete(any());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/menu-group/delete-menu/{menuId}", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/menu-group/delete-menu/{menuId}", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt));
 
             // then
@@ -460,7 +459,7 @@ class MenuGroupControllerTest {
             doNothing().when(menuGroupService).updateMenuPosition(anyLong(), anyList());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/menu-group/{menuGroupId}/change-menu-position", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/owner/menu-group/{menuGroupId}/change-menu-position", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));

--- a/src/test/java/toy/yogiyo/api/owner/MenuOptionGroupControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/owner/MenuOptionGroupControllerTest.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +19,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import toy.yogiyo.api.member.MenuOptionGroupController;
 import toy.yogiyo.core.menu.domain.Menu;
 import toy.yogiyo.core.menuoption.domain.MenuOption;
 import toy.yogiyo.core.menuoption.domain.MenuOptionGroup;
@@ -98,7 +97,7 @@ class MenuOptionGroupControllerTest {
                     .build();
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/menu-option-group/shop/{shopId}/add", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/owner/menu-option-group/shop/{shopId}/add", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -141,7 +140,7 @@ class MenuOptionGroupControllerTest {
                             .build());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/menu-option-group/{menuOptionGroupId}", 1));
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/menu-option-group/{menuOptionGroupId}", 1));
 
             // then
             result.andExpect(status().isOk())
@@ -200,7 +199,7 @@ class MenuOptionGroupControllerTest {
             given(menuOptionGroupService.getAll(anyLong())).willReturn(Arrays.asList(menuOptionGroup1, menuOptionGroup2));
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/menu-option-group/shop/{shopId}", 1));
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/menu-option-group/shop/{shopId}", 1));
 
             // then
             result.andExpect(status().isOk())
@@ -243,7 +242,7 @@ class MenuOptionGroupControllerTest {
                     .build();
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/menu-option-group/{menuOptionGroupId}/update", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/menu-option-group/{menuOptionGroupId}/update", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -271,7 +270,7 @@ class MenuOptionGroupControllerTest {
             doNothing().when(menuOptionGroupService).delete(anyLong());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/menu-option-group/{menuOptionGroupId}/delete", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/menu-option-group/{menuOptionGroupId}/delete", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt));
 
             // then
@@ -297,7 +296,7 @@ class MenuOptionGroupControllerTest {
                     .build();
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/menu-option-group/{menuOptionGroupId}/link-menu", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/owner/menu-option-group/{menuOptionGroupId}/link-menu", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -329,7 +328,7 @@ class MenuOptionGroupControllerTest {
                     .build();
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/menu-option-group/shop/{shopId}/change-position", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/owner/menu-option-group/shop/{shopId}/change-position", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -367,7 +366,7 @@ class MenuOptionGroupControllerTest {
                     .build();
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/menu-option-group/{menuOptionGroupId}/add-option", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/owner/menu-option-group/{menuOptionGroupId}/add-option", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -407,7 +406,7 @@ class MenuOptionGroupControllerTest {
                             .build());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/menu-option-group/option/{menuOptionId}", 1));
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/menu-option-group/option/{menuOptionId}", 1));
 
             // then
             result.andExpect(status().isOk())
@@ -438,7 +437,7 @@ class MenuOptionGroupControllerTest {
                     .build();
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/menu-option-group/option/{menuOptionId}/update", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/menu-option-group/option/{menuOptionId}/update", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));
@@ -468,7 +467,7 @@ class MenuOptionGroupControllerTest {
             doNothing().when(menuOptionService).delete(anyLong());
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/menu-option-group/option/{menuOptionId}/delete", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/menu-option-group/option/{menuOptionId}/delete", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt));
 
             // then
@@ -494,7 +493,7 @@ class MenuOptionGroupControllerTest {
                     .build();
 
             // when
-            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/menu-option-group/{menuOptionGroupId}/change-option-position", 1)
+            ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/owner/menu-option-group/{menuOptionGroupId}/change-option-position", 1)
                     .header(HttpHeaders.AUTHORIZATION, jwt)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request)));

--- a/src/test/java/toy/yogiyo/api/owner/ReviewManagementControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/owner/ReviewManagementControllerTest.java
@@ -109,7 +109,7 @@ class ReviewManagementControllerTest {
                 .build();
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/management/review/shop/{shopId}", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/review/shop/{shopId}", 1)
                 .param("sort", condition.getSort().name())
                 .param("startDate", condition.getStartDate().toString())
                 .param("endDate", condition.getEndDate().toString())
@@ -162,7 +162,7 @@ class ReviewManagementControllerTest {
                 .build();
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/management/review/{reviewId}/reply", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/review/{reviewId}/reply", 1)
                 .header(HttpHeaders.AUTHORIZATION, jwt)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
@@ -190,7 +190,7 @@ class ReviewManagementControllerTest {
         doNothing().when(reviewManagementService).deleteReply(anyLong());
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/management/review/{reviewId}/reply", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/review/{reviewId}/reply", 1)
                 .header(HttpHeaders.AUTHORIZATION, jwt));
 
         // then

--- a/src/test/java/toy/yogiyo/api/owner/ShopControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/owner/ShopControllerTest.java
@@ -1,0 +1,507 @@
+package toy.yogiyo.api.owner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import toy.yogiyo.common.security.WithLoginOwner;
+import toy.yogiyo.core.category.domain.Category;
+import toy.yogiyo.core.category.domain.CategoryShop;
+import toy.yogiyo.core.shop.domain.BusinessHours;
+import toy.yogiyo.core.shop.domain.CloseDay;
+import toy.yogiyo.core.shop.domain.Days;
+import toy.yogiyo.core.shop.domain.Shop;
+import toy.yogiyo.core.shop.dto.*;
+import toy.yogiyo.core.shop.service.ShopService;
+import toy.yogiyo.util.ConstrainedFields;
+
+import java.io.IOException;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static toy.yogiyo.document.utils.DocumentLinkGenerator.DocUrl.DAYS;
+import static toy.yogiyo.document.utils.DocumentLinkGenerator.generateLinkCode;
+
+@WebMvcTest(ShopController.class)
+@ExtendWith(RestDocumentationExtension.class)
+class ShopControllerTest {
+
+    @MockBean
+    ShopService shopService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    ObjectMapper objectMapper;
+
+    final String jwt = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIsInByb3ZpZGVyVHlwZSI6IkRFRkFVTFQiLCJleHAiOjE2OTQ5NjY4Mjh9.Ls1wnxU41I99ijXRyKfkYI2w3kd-Q_qA2QgCLgpDTKk";
+
+    @BeforeEach
+    void beforeEach(WebApplicationContext context, RestDocumentationContextProvider restDocumentationContextProvider) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentationContextProvider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+
+        objectMapper = new ObjectMapper();
+    }
+
+
+    @Test
+    @DisplayName("가게 입점")
+    @WithLoginOwner
+    void register() throws Exception {
+        // given
+        ShopRegisterRequest registerRequest = ShopRegisterRequest.builder()
+                .name("롯데리아")
+                .callNumber("010-1234-5678")
+                .address("서울 강남구 영동대로 513")
+                .latitude(36.674648)
+                .longitude(127.448544)
+                .categories(Arrays.asList("치킨", "한식", "중국집"))
+                .build();
+
+        MockMultipartFile requestJson = new MockMultipartFile(
+                "shopData",
+                "jsonData",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(registerRequest).getBytes());
+        MockMultipartFile icon = givenIcon();
+        MockMultipartFile banner = givenBanner();
+        when(shopService.register(any(), any(), any(), any())).thenReturn(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(multipart("/owner/shop/register")
+                .file(icon)
+                .file(banner)
+                .file(requestJson)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .contentType(MediaType.MULTIPART_FORM_DATA));
+
+        // then
+        ConstrainedFields fields = new ConstrainedFields(ShopRegisterRequest.class);
+        result.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andDo(print())
+                .andDo(document("shop/register",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
+                        ),
+                        requestParts(
+                                partWithName("icon").description("아이콘"),
+                                partWithName("banner").description("배너 이미지"),
+                                partWithName("shopData").description("가게 정보")
+                        ),
+                        requestPartFields("shopData",
+                                fields.withPath("name").type(JsonFieldType.STRING).description("가게명"),
+                                fields.withPath("callNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fields.withPath("address").type(JsonFieldType.STRING).description("주소"),
+                                fields.withPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+                                fields.withPath("longitude").type(JsonFieldType.NUMBER).description("경도"),
+                                fields.withPath("categories").type(JsonFieldType.ARRAY).description("카테고리 Array")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 ID")
+                        )
+                ));
+    }
+
+
+    @Test
+    @DisplayName("가게 정보 조회")
+    void getInfo() throws Exception {
+        // given
+        ShopInfoResponse response = ShopInfoResponse.from(givenShop());
+        when(shopService.getInfo(anyLong())).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/shop/{shopId}/info", 1L));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(response.getId()))
+                .andExpect(jsonPath("$.name").value(response.getName()))
+                .andExpect(jsonPath("$.callNumber").value(response.getCallNumber()))
+                .andExpect(jsonPath("$.address").value(response.getAddress()))
+                .andExpect(jsonPath("$.categories").isArray())
+                .andExpect(jsonPath("$.categories.length()").value(response.getCategories().size()))
+                .andDo(print())
+                .andDo(document("shop/get-info",
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 ID"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("가게명"),
+                                fieldWithPath("callNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fieldWithPath("address").type(JsonFieldType.STRING).description("주소"),
+                                fieldWithPath("categories").type(JsonFieldType.ARRAY).description("카테고리명 리스트")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("사장님 공지 조회")
+    void getNotice() throws Exception {
+        // given
+        ShopNoticeResponse response = ShopNoticeResponse.builder()
+                .title("공지 제목")
+                .notice("공지 내용")
+                .images(List.of("/images/image1.png", "/images/image2.png"))
+                .build();
+        when(shopService.getNotice(anyLong())).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/shop/{shopId}/notice", 1));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("공지 제목"))
+                .andExpect(jsonPath("$.notice").value("공지 내용"))
+                .andExpect(jsonPath("$.images[0]").value("/images/image1.png"))
+                .andExpect(jsonPath("$.images[1]").value("/images/image2.png"))
+                .andDo(print())
+                .andDo(document("shop/get-notice",
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("title").type(JsonFieldType.STRING).description("사장님 공지 제목"),
+                                fieldWithPath("notice").type(JsonFieldType.STRING).description("사장님 공지 내용"),
+                                fieldWithPath("images").type(JsonFieldType.ARRAY).description("사장님 공지 사진 리스트")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("영업 시간 조회")
+    void getBusinessHours() throws Exception {
+        // given
+        ShopBusinessHourResponse response = ShopBusinessHourResponse.builder()
+                .businessHours(List.of(
+                        new ShopBusinessHourResponse.BusinessHoursDto(BusinessHours.builder()
+                                .dayOfWeek(Days.EVERYDAY)
+                                .isOpen(true)
+                                .openTime(LocalTime.of(10, 0))
+                                .closeTime(LocalTime.of(20, 0))
+                                .build()
+                        )
+                ))
+                .build();
+        when(shopService.getBusinessHours(anyLong())).thenReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/shop/{shopId}/business-hours", 1));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.businessHours.length()").value(1))
+                .andExpect(jsonPath("$.businessHours[0].dayOfWeek").value("EVERYDAY"))
+                .andExpect(jsonPath("$.businessHours[0].openTime").value("10:00:00"))
+                .andDo(print())
+                .andDo(document("shop/get-business-hours",
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("businessHours").type(JsonFieldType.ARRAY).description("영업 시간"),
+                                fieldWithPath("businessHours[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS)),
+                                fieldWithPath("businessHours[].isOpen").type(JsonFieldType.BOOLEAN).description("영업일"),
+                                fieldWithPath("businessHours[].openTime").type(JsonFieldType.STRING).description("오픈 시간"),
+                                fieldWithPath("businessHours[].closeTime").type(JsonFieldType.STRING).description("마감 시간"),
+                                fieldWithPath("businessHours[].breakTimeStart").type(JsonFieldType.STRING).description("휴게 시간 (시작)").optional(),
+                                fieldWithPath("businessHours[].breakTimeEnd").type(JsonFieldType.STRING).description("휴게 시간 (종료)").optional()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("휴무일 조회")
+    void getCloseDays() throws Exception {
+        // given
+        when(shopService.getCloseDays(anyLong())).thenReturn(ShopCloseDayResponse.builder()
+                .closeDays(List.of(
+                        new ShopCloseDayResponse.CloseDayDto(CloseDay.builder().weekNumOfMonth(1).dayOfWeek(Days.MONDAY).build()),
+                        new ShopCloseDayResponse.CloseDayDto(CloseDay.builder().weekNumOfMonth(3).dayOfWeek(Days.MONDAY).build())
+                ))
+                .build());
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/shop/{shopId}/close-day", 1));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.closeDays[0].weekNumOfMonth").value(1))
+                .andExpect(jsonPath("$.closeDays[0].dayOfWeek").value("MONDAY"))
+                .andExpect(jsonPath("$.closeDays[1].weekNumOfMonth").value(3))
+                .andExpect(jsonPath("$.closeDays[1].dayOfWeek").value("MONDAY"))
+                .andDo(print())
+                .andDo(document("shop/get-close-day",
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("closeDays").type(JsonFieldType.ARRAY).description("휴무일 리스트"),
+                                fieldWithPath("closeDays[].weekNumOfMonth").type(JsonFieldType.NUMBER).description("(1~4)번째 주"),
+                                fieldWithPath("closeDays[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS))
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("가게 전화번호 수정")
+    @WithLoginOwner
+    void updateCallNumber() throws Exception {
+        // given
+        ShopUpdateCallNumberRequest updateRequest = ShopUpdateCallNumberRequest.builder()
+                .callNumber("010-1234-5678")
+                .build();
+
+        doNothing().when(shopService).updateCallNumber(anyLong(), any(), any());
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/shop/{shopId}/call-number/update", 1L)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(updateRequest)));
+
+        // then
+        ConstrainedFields fields = new ConstrainedFields(ShopUpdateCallNumberRequest.class);
+        result.andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("shop/update-call-number",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
+                        ),
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        requestFields(
+                                fields.withPath("callNumber").type(JsonFieldType.STRING).description("전화번호")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("사장님 공지 수정")
+    @WithLoginOwner
+    void updateNotice() throws Exception {
+        // given
+        doNothing().when(shopService).updateNotice(anyLong(), any(), any(), anyList());
+        ShopNoticeUpdateRequest request = ShopNoticeUpdateRequest.builder()
+                .title("공지 제목")
+                .notice("사장님 공지")
+                .build();
+        MockMultipartFile image1 = new MockMultipartFile("images", "image1.png", MediaType.IMAGE_PNG_VALUE, "<<image.png>>".getBytes());
+        MockMultipartFile image2 = new MockMultipartFile("images", "image2.png", MediaType.IMAGE_PNG_VALUE, "<<image.png>>".getBytes());
+        MockMultipartFile image3 = new MockMultipartFile("images", "image3.png", MediaType.IMAGE_PNG_VALUE, "<<image.png>>".getBytes());
+        MockMultipartFile requestJson = new MockMultipartFile(
+                "noticeData",
+                "jsonData",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(request).getBytes());
+
+
+        // when
+        ConstrainedFields fields = new ConstrainedFields(ShopNoticeUpdateRequest.class);
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.multipart("/owner/shop/{shopId}/notice/update", 1)
+                .file(image1)
+                .file(image2)
+                .file(image3)
+                .file(requestJson)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .contentType(MediaType.MULTIPART_FORM_DATA));
+
+        // then
+        result.andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("shop/update-notice",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
+                        ),
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        requestParts(
+                                partWithName("images").description("첨부 사진"),
+                                partWithName("noticeData").description("공지 Json")
+                        ),
+                        requestPartFields("noticeData",
+                                fields.withPath("title").type(JsonFieldType.STRING).description("공지 제목"),
+                                fields.withPath("notice").type(JsonFieldType.STRING).description("공지 내용")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("영업 시간 수정")
+    @WithLoginOwner
+    void updateBusinessHours() throws Exception {
+        // given
+        doNothing().when(shopService).updateBusinessHours(anyLong(), any(), any());
+        ShopBusinessHourUpdateRequest request = ShopBusinessHourUpdateRequest.builder()
+                .businessHours(List.of(
+                        new ShopBusinessHourUpdateRequest.BusinessHoursDto(
+                                Days.EVERYDAY,
+                                true,
+                                LocalTime.of(10, 0),
+                                LocalTime.of(20, 0),
+                                null,
+                                null)
+                ))
+                .build();
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/shop/{shopId}/business-hours/update", 1)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .characterEncoding("utf8"));
+
+        // then
+        ConstrainedFields fields = new ConstrainedFields(ShopBusinessHourUpdateRequest.class);
+        result.andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("shop/update-business-hours",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
+                        ),
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        requestFields(
+                                fields.withPath("businessHours").type(JsonFieldType.ARRAY).description("영업 시간"),
+                                fields.withPath("businessHours[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS)),
+                                fields.withPath("businessHours[].isOpen").type(JsonFieldType.BOOLEAN).description("영업일"),
+                                fields.withPath("businessHours[].openTime").type(JsonFieldType.STRING).description("오픈 시간"),
+                                fields.withPath("businessHours[].closeTime").type(JsonFieldType.STRING).description("마감 시간"),
+                                fields.withPath("businessHours[].breakTimeStart").type(JsonFieldType.STRING).description("휴게 시간 (시작)").optional(),
+                                fields.withPath("businessHours[].breakTimeEnd").type(JsonFieldType.STRING).description("휴게 시간 (종료)").optional()
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("휴무일 수정")
+    void updateCloseDays() throws Exception {
+        // given
+        doNothing().when(shopService).updateCloseDays(anyLong(), any(), any());
+        ShopCloseDayUpdateRequest request = ShopCloseDayUpdateRequest.builder()
+                .closeDays(List.of(
+                        new ShopCloseDayUpdateRequest.CloseDayDto(1, Days.MONDAY),
+                        new ShopCloseDayUpdateRequest.CloseDayDto(3, Days.MONDAY)
+                ))
+                .build();
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.patch("/owner/shop/{shopId}/close-day/update", 1)
+                .header(HttpHeaders.AUTHORIZATION, jwt)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        ConstrainedFields fields = new ConstrainedFields(ShopCloseDayUpdateRequest.class);
+        result.andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("shop/update-close-day",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
+                        ),
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        ),
+                        requestFields(
+                                fields.withPath("closeDays").type(JsonFieldType.ARRAY).description("휴무일 리스트"),
+                                fields.withPath("closeDays[].weekNumOfMonth").type(JsonFieldType.NUMBER).description("(1~4)번째 주"),
+                                fields.withPath("closeDays[].dayOfWeek").type(JsonFieldType.STRING).description(generateLinkCode(DAYS))
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("가게 삭제")
+    @WithLoginOwner
+    void deleteShop() throws Exception {
+        // given
+        doNothing().when(shopService).delete(anyLong(), any());
+
+        // when
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/shop/{shopId}/delete", 1L)
+                .header(HttpHeaders.AUTHORIZATION, jwt));
+
+        // then
+        verify(shopService).delete(anyLong(), any());
+        result.andExpect(status().isNoContent())
+                .andDo(print())
+                .andDo(document("shop/delete",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access token")
+                        ),
+                        pathParameters(
+                                parameterWithName("shopId").description("가게 ID")
+                        )
+                ));
+    }
+
+    private Shop givenShop() {
+        Shop shop = Shop.builder()
+                .id(1L)
+                .name("롯데리아")
+                .icon("692c0741-f234-448e-ba3f-35b5a394f33d.png")
+                .banner("692c0741-f234-448e-ba3f-35b5a394f33d.png")
+                .ownerNotice("사장님 공지")
+                .callNumber("010-1234-5678")
+                .address("서울 강남구 영동대로 513")
+                .categoryShop(Arrays.asList(
+                        CategoryShop.builder().category(Category.builder().name("카테고리1").build()).build(),
+                        CategoryShop.builder().category(Category.builder().name("카테고리2").build()).build(),
+                        CategoryShop.builder().category(Category.builder().name("카테고리3").build()).build(),
+                        CategoryShop.builder().category(Category.builder().name("카테고리4").build()).build()
+                ))
+                .build();
+
+        return shop;
+    }
+
+    private MockMultipartFile givenIcon() throws IOException {
+        return new MockMultipartFile("icon", "images.png", MediaType.IMAGE_PNG_VALUE, "<<image png>>".getBytes());
+    }
+
+    private MockMultipartFile givenBanner() throws IOException {
+        return new MockMultipartFile("banner", "images.png", MediaType.IMAGE_PNG_VALUE, "<<image png>>".getBytes());
+    }
+}

--- a/src/test/java/toy/yogiyo/api/owner/SignatureMenuControllerTest.java
+++ b/src/test/java/toy/yogiyo/api/owner/SignatureMenuControllerTest.java
@@ -1,4 +1,4 @@
-package toy.yogiyo.api.member;
+package toy.yogiyo.api.owner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +18,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import toy.yogiyo.api.member.SignatureMenuController;
 import toy.yogiyo.core.menu.domain.Menu;
 import toy.yogiyo.core.menu.domain.SignatureMenu;
 import toy.yogiyo.core.menu.dto.SignatureMenuUpdatePositionRequest;
@@ -81,7 +80,7 @@ class SignatureMenuControllerTest {
                 .build();
 
         // when
-        ResultActions result = mockMvc.perform(put("/signature-menu/set")
+        ResultActions result = mockMvc.perform(put("/owner/signature-menu/set")
                 .header(HttpHeaders.AUTHORIZATION, jwt)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
@@ -114,7 +113,7 @@ class SignatureMenuControllerTest {
         given(signatureMenuService.getAll(anyLong())).willReturn(signatureMenus);
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/signature-menu/shop/{shopId}", 1));
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/owner/signature-menu/shop/{shopId}", 1));
 
         // then
         result.andExpect(status().isOk())
@@ -148,7 +147,7 @@ class SignatureMenuControllerTest {
         doNothing().when(signatureMenuService).delete(anyLong());
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/signature-menu/delete/{menuId}", 1));
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.delete("/owner/signature-menu/delete/{menuId}", 1));
 
         // then
         result.andExpect(status().isNoContent())
@@ -170,7 +169,7 @@ class SignatureMenuControllerTest {
                 .build();
 
         // when
-        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/signature-menu/{shopId}/change-position", 1)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.put("/owner/signature-menu/{shopId}/change-position", 1)
                 .header(HttpHeaders.AUTHORIZATION, jwt)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));

--- a/src/test/java/toy/yogiyo/common/login/LoginControllerTest.java
+++ b/src/test/java/toy/yogiyo/common/login/LoginControllerTest.java
@@ -89,7 +89,7 @@ class LoginControllerTest {
         given(loginService.memberLogin(any())).willReturn(loginResponse);
         given(jwtProvider.createToken(any(), any(), any())).willReturn(jwt);
 
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/memberLogin")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/member/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsBytes(loginRequest))
                 )
@@ -135,7 +135,7 @@ class LoginControllerTest {
         given(loginService.memberLogin(any())).willReturn(loginResponse);
         given(jwtProvider.createToken(any(), any(), any())).willReturn(jwt);
 
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/memberLogin")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/member/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(loginRequest))
                 )
@@ -175,7 +175,7 @@ class LoginControllerTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken(member, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/memberLogout/{memberId}", 1L)
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/member/logout/{memberId}", 1L)
                         .header("Authorization", "Bearer " + jwt)
                 )
                 .andExpect(status().isOk())
@@ -212,7 +212,7 @@ class LoginControllerTest {
         given(loginService.ownerLogin(any())).willReturn(loginResponse);
         given(jwtProvider.createToken(any(), any(), any())).willReturn(jwt);
 
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/ownerLogin")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/owner/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(loginRequest))
                 )
@@ -256,7 +256,7 @@ class LoginControllerTest {
         given(loginService.ownerLogin(any())).willReturn(loginResponse);
         given(jwtProvider.createToken(any(), any(), any())).willReturn(jwt);
 
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/ownerLogin")
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/owner/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(loginRequest))
                 )
@@ -295,7 +295,7 @@ class LoginControllerTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken(owner, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/ownerLogout/{ownerId}", 1L)
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/owner/logout/{ownerId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + jwt)
                 )

--- a/src/test/java/toy/yogiyo/common/security/WithLoginMember.java
+++ b/src/test/java/toy/yogiyo/common/security/WithLoginMember.java
@@ -7,10 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
-@WithSecurityContext(factory = WithLoginOwnerSecurityContextFactory.class)
-public @interface WithLoginOwner {
+@WithSecurityContext(factory = WithLoginMemberSecurityContextFactory.class)
+public @interface WithLoginMember {
     long id() default 1L;
-    String nickname() default "owner1";
-    String email() default "owner1@test.com";
+    String nickname() default "member1";
+    String email() default "member1@test.com";
     ProviderType providerType() default ProviderType.DEFAULT;
 }

--- a/src/test/java/toy/yogiyo/common/security/WithLoginMemberSecurityContextFactory.java
+++ b/src/test/java/toy/yogiyo/common/security/WithLoginMemberSecurityContextFactory.java
@@ -1,0 +1,30 @@
+package toy.yogiyo.common.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import toy.yogiyo.core.member.domain.Member;
+
+import java.util.List;
+
+public class WithLoginMemberSecurityContextFactory implements WithSecurityContextFactory<WithLoginMember> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithLoginMember annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        Member member = Member.builder()
+                .id(annotation.id())
+                .nickname(annotation.nickname())
+                .email(annotation.email())
+                .providerType(annotation.providerType())
+                .build();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        context.setAuthentication(authentication);
+        return context;
+    }
+}


### PR DESCRIPTION
## owner, member API 분리
- api를 구분할 수 있도록 prefix 적용
- 점주가 사용하는 api => `/owner/XXX`
- 고객이 사용하는 api => `/member/XXX`
- login api url 수정 `/xxxrLogin` => `/xxx/login`, `/xxxLogout` => `/xxx/logout`

## 가게 상세 페이지 관련 API 추가
- 가게 정보 조회 (상호명, 주문 금액, 배달 금액, 찜 개수, 리뷰 개수 등)
- 가게 원산지 정보 조회
-  음식 상세 정보 조회
