### PR TITLE
메뉴 하루품절 초기화, 가게 일시중지 기능 추가

### DIFF
--- a/src/docs/asciidoc/Shop-API.adoc
+++ b/src/docs/asciidoc/Shop-API.adoc
@@ -76,3 +76,8 @@ operation::shop/details[snippets='http-request,http-response,request-parameters,
 `GET /member/shop/{shop id}/info`
 
 operation::member/shop/info[snippets='http-request,http-response,path-parameters,request-parameters,response-fields']
+
+=== 가게 일시중지
+`PATCH /owner/shop/{shop id}/temp-close`
+
+operation::shop/temp-close[snippets='http-request,http-response,path-parameters,request-fields']

--- a/src/main/java/toy/yogiyo/api/owner/MenuGroupController.java
+++ b/src/main/java/toy/yogiyo/api/owner/MenuGroupController.java
@@ -137,7 +137,7 @@ public class MenuGroupController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("@menuPermissionEvaluator.hasWritePermission(authentication, #menuId)")
     public void updateMenuVisible(@PathVariable Long menuId, @Validated @RequestBody MenuVisibleUpdateRequest request) {
-        menuService.updateHide(menuId, request.getVisible());
+        menuService.updateVisible(menuId, request.getVisible());
     }
 
     @GetMapping("/search")

--- a/src/main/java/toy/yogiyo/api/owner/ShopController.java
+++ b/src/main/java/toy/yogiyo/api/owner/ShopController.java
@@ -92,6 +92,15 @@ public class ShopController {
         shopService.updateCloseDays(shopId, owner, request);
     }
 
+    @PatchMapping("/{shopId}/temp-close")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void tempClose(@LoginOwner Owner owner,
+                          @PathVariable Long shopId,
+                          @Validated @RequestBody ShopTempCloseRequest request) {
+
+        shopService.tempClose(shopId, owner, request);
+    }
+
 
     @DeleteMapping("/{shopId}/delete")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/toy/yogiyo/common/config/SchedulerConfig.java
+++ b/src/main/java/toy/yogiyo/common/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package toy.yogiyo.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/toy/yogiyo/common/exception/ErrorCode.java
+++ b/src/main/java/toy/yogiyo/common/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
     SHOP_ACCESS_DENIED(403, "SH_002", "가게에 대한 권한이 없습니다."),
     SHOP_ALREADY_EXIST(409, "SH_003", "이미 존재하는 가게명 입니다."),
 
+    BUSINESSHOURS_NOT_FOUND(404, "BH_001", "영업 시간이 존재하지 않습니다."),
+
     CATEGORY_NOT_FOUND(404, "C_001", "카테고리를 찾을 수 없습니다."),
     CATEGORY_ALREADY_EXIST(409, "C_002", "이미 존재하는 카테고리명 입니다."),
 

--- a/src/main/java/toy/yogiyo/core/menu/domain/Menu.java
+++ b/src/main/java/toy/yogiyo/core/menu/domain/Menu.java
@@ -7,6 +7,7 @@ import toy.yogiyo.common.dto.Visible;
 import toy.yogiyo.core.menuoption.domain.OptionGroupLinkMenu;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +34,7 @@ public class Menu {
     @ColumnDefault("'SHOW'")
     @Enumerated(EnumType.STRING)
     private Visible visible;
+    private LocalDateTime soldOutUntil;
 
     private long reviewNum;
 
@@ -72,7 +74,8 @@ public class Menu {
         this.reviewNum++;
     }
 
-    public void updateVisible(Visible visible) {
+    public void updateVisible(Visible visible, LocalDateTime soldOutUntil) {
         this.visible = visible;
+        this.soldOutUntil = soldOutUntil;
     }
 }

--- a/src/main/java/toy/yogiyo/core/menu/repository/MenuRepository.java
+++ b/src/main/java/toy/yogiyo/core/menu/repository/MenuRepository.java
@@ -1,11 +1,13 @@
 package toy.yogiyo.core.menu.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import toy.yogiyo.core.menu.domain.Menu;
 import toy.yogiyo.core.menu.domain.MenuGroup;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
@@ -18,4 +20,8 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     @Query("select m from Menu m where m.id in :menuIds")
     List<Menu> findMenus(@Param("menuIds") Long[] menuIds);
+
+    @Modifying
+    @Query("update Menu m set m.soldOutUntil = null, m.visible = toy.yogiyo.common.dto.Visible.SHOW where m.soldOutUntil <= :datetime")
+    void updateAllSoldOutFinishByDateTime(@Param("datetime") LocalDateTime dateTime);
 }

--- a/src/main/java/toy/yogiyo/core/shop/domain/Shop.java
+++ b/src/main/java/toy/yogiyo/core/shop/domain/Shop.java
@@ -64,6 +64,8 @@ public class Shop extends BaseTimeEntity {
     private Double longitude;
     private Double latitude;
 
+    private LocalDateTime closeUntil;
+
     @Builder.Default
     @OneToMany(mappedBy = "shop", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CategoryShop> categoryShop = new ArrayList<>();
@@ -148,6 +150,10 @@ public class Shop extends BaseTimeEntity {
                 .withHour(tomorrowOpenTime.getHour())
                 .withMinute(tomorrowOpenTime.getMinute())
                 .withSecond(tomorrowOpenTime.getSecond());
+    }
+
+    public void updateCloseUntil(LocalDateTime closeUntil) {
+        this.closeUntil = closeUntil;
     }
 }
 

--- a/src/main/java/toy/yogiyo/core/shop/domain/Shop.java
+++ b/src/main/java/toy/yogiyo/core/shop/domain/Shop.java
@@ -1,17 +1,19 @@
 package toy.yogiyo.core.shop.domain;
 
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import toy.yogiyo.common.converter.StringArrayConverter;
 import toy.yogiyo.common.domain.BaseTimeEntity;
-import toy.yogiyo.core.deliveryplace.domain.DeliveryPlace;
+import toy.yogiyo.common.exception.EntityNotFoundException;
+import toy.yogiyo.common.exception.ErrorCode;
 import toy.yogiyo.core.review.domain.Review;
 import toy.yogiyo.core.category.domain.CategoryShop;
 import toy.yogiyo.core.owner.domain.Owner;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -131,6 +133,21 @@ public class Shop extends BaseTimeEntity {
 
     public void increaseLikeNum() {
         this.likeNum++;
+    }
+
+    public LocalDateTime getOpenTime(LocalDateTime dateTime) {
+        Days tomorrowDays = Days.valueOf(dateTime.getDayOfWeek().name());
+
+        LocalTime tomorrowOpenTime = this.getBusinessHours().stream()
+                .filter((hours) -> hours.getDayOfWeek() == Days.EVERYDAY || hours.getDayOfWeek() == tomorrowDays)
+                .findFirst()
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BUSINESSHOURS_NOT_FOUND))
+                .getOpenTime();
+
+        return dateTime
+                .withHour(tomorrowOpenTime.getHour())
+                .withMinute(tomorrowOpenTime.getMinute())
+                .withSecond(tomorrowOpenTime.getSecond());
     }
 }
 

--- a/src/main/java/toy/yogiyo/core/shop/dto/ShopTempCloseRequest.java
+++ b/src/main/java/toy/yogiyo/core/shop/dto/ShopTempCloseRequest.java
@@ -1,0 +1,19 @@
+package toy.yogiyo.core.shop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShopTempCloseRequest {
+
+    private LocalDateTime closeUntil;
+    private Boolean today;
+
+}

--- a/src/main/java/toy/yogiyo/core/shop/repository/ShopRepository.java
+++ b/src/main/java/toy/yogiyo/core/shop/repository/ShopRepository.java
@@ -2,11 +2,13 @@ package toy.yogiyo.core.shop.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import toy.yogiyo.core.shop.domain.Shop;
 
 import javax.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface ShopRepository extends JpaRepository<Shop, Long>, ShopCustomRepository {
@@ -22,4 +24,8 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopCustomRep
             " join Menu m on m.menuGroup.id = mg.id" +
             " where m.id = :menuId")
     Optional<Shop> findByMenu(@Param("menuId") Long menuId);
+
+    @Modifying
+    @Query("update Shop s set s.closeUntil = null where s.closeUntil <= :datetime")
+    void updateAllTempCloseFinishByDateTime(@Param("datetime") LocalDateTime dateTime);
 }

--- a/src/main/java/toy/yogiyo/core/shop/repository/ShopRepository.java
+++ b/src/main/java/toy/yogiyo/core/shop/repository/ShopRepository.java
@@ -2,6 +2,8 @@ package toy.yogiyo.core.shop.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import toy.yogiyo.core.shop.domain.Shop;
 
 import javax.persistence.LockModeType;
@@ -14,4 +16,10 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopCustomRep
     @Override
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Shop> findById(Long aLong);
+
+    @Query("select s from Shop s" +
+            " join MenuGroup mg on mg.shop.id = s.id" +
+            " join Menu m on m.menuGroup.id = mg.id" +
+            " where m.id = :menuId")
+    Optional<Shop> findByMenu(@Param("menuId") Long menuId);
 }


### PR DESCRIPTION
#### 메뉴 하루품절 초기화
- `soldOutUntil` 컬럼 추가
- 스케쥴링 기능을 사용해서 10분 간격으로 `soldOutUntil` 날짜가 지난 데이터는 다시 보이도록 update 쿼리 수행

#### 가게 일시중지
- 가게 일시중지 API 추가
- `closeUntil` 컬럼 추가
- 스케쥴링 기능을 사용해서 10분 간격으로 `closeUntil` 날짜가 지난 데이터는 다시 보이도록 update 쿼리 수행
